### PR TITLE
Allow caching of commodity and constraint types

### DIFF
--- a/src/load_inputs/load_commodities.jl
+++ b/src/load_inputs/load_commodities.jl
@@ -1,5 +1,15 @@
+const COMMODITY_TYPES = Dict{Symbol,DataType}()
+
+function register_commodity_types!(m::Module = Macro)
+    empty!(COMMODITY_TYPES)
+    for (commodity_name, commodity_type) in all_subtypes(m, :Commodity)
+        COMMODITY_TYPES[commodity_name] = commodity_type
+    end
+end
+
 function commodity_types(m::Module = Macro)
-    return all_subtypes(m, :Commodity)
+    isempty(COMMODITY_TYPES) && register_commodity_types!(m)
+    return COMMODITY_TYPES
 end
 
 function load_commodities(path::AbstractString, rel_path::AbstractString)

--- a/src/model/constraints/constraints_utils.jl
+++ b/src/model/constraints/constraints_utils.jl
@@ -31,6 +31,16 @@ function add_constraints_by_type!(
     end
 end
 
+const CONSTRAINT_TYPES = Dict{Symbol,DataType}()
+
+function register_constraint_types!(m::Module = Macro)
+    empty!(CONSTRAINT_TYPES)
+    for (constraint_name, constraint_type) in all_subtypes(m, :AbstractTypeConstraint)
+        CONSTRAINT_TYPES[constraint_name] = constraint_type
+    end
+end
+
 function constraint_types(m::Module = Macro)
-    return all_subtypes(m, :AbstractTypeConstraint)
+    isempty(CONSTRAINT_TYPES) && register_constraint_types!(m)
+    return CONSTRAINT_TYPES
 end


### PR DESCRIPTION
This PR enables caching for both the dict of commodity types and constraint types, speeding up data loading. (Ref. `subtypes` call appears to be particularly costly).