### PR TITLE
bugfix + update tests

### DIFF
--- a/ExampleSystems/eastern_us_three_zones/assets/h2gas_power_ccgt.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/h2gas_power_ccgt.json
@@ -44,7 +44,7 @@
                     "id": "SE_CCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges":{
                             "elec_edge": {
@@ -77,7 +77,7 @@
                     "id": "MIDAT_CCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges":{
                             "elec_edge": {
@@ -110,7 +110,7 @@
                     "id": "NE_CCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges":{
                             "elec_edge": {

--- a/ExampleSystems/eastern_us_three_zones/assets/h2gas_power_ocgt.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/h2gas_power_ocgt.json
@@ -42,7 +42,7 @@
                     "id": "SE_OCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges":{
                             "elec_edge": {
@@ -73,7 +73,7 @@
                     "id": "MIDAT_OCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges":{
                             "elec_edge": {
@@ -104,7 +104,7 @@
                     "id": "NE_OCGT-H2",
                     "transforms":{
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges":{
                             "elec_edge": {

--- a/ExampleSystems/eastern_us_three_zones/assets/naturalgas_h2.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/naturalgas_h2.json
@@ -50,7 +50,7 @@
                     "id": "SE_Large_SMR_Non_CCS",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.76865951,
+                        "fuel_consumption": 1.3009661455954666,
                         "electricity_consumption": 0.016404
                     },
                     "edges":{
@@ -86,7 +86,7 @@
                     "id": "MIDAT_Large_SMR_Non_CCS",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.76865951,
+                        "fuel_consumption": 1.3009661455954666,
                         "electricity_consumption": 0.016404
                     },
                     "edges":{
@@ -122,7 +122,7 @@
                     "id": "NE_Large_SMR_Non_CCS",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.76865951,
+                        "fuel_consumption": 1.3009661455954666,
                         "electricity_consumption": 0.016404
                     },
                     "edges":{

--- a/ExampleSystems/eastern_us_three_zones/assets/naturalgas_h2_ccs.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/naturalgas_h2_ccs.json
@@ -56,7 +56,7 @@
                     "id": "SE_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },
@@ -93,7 +93,7 @@
                     "id": "MIDAT_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },
@@ -130,7 +130,7 @@
                     "id": "NE_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },
@@ -167,7 +167,7 @@
                     "id": "SE_Large_SMR_wCCS_96pct",
                     "transforms":{
                         "emission_rate": 0.006879832936086124,
-                        "efficiency_rate": 0.72289814,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.051727,
                         "capture_rate": 0.17416840222407487
                     },
@@ -204,7 +204,7 @@
                     "id": "MIDAT_Large_SMR_wCCS_96pct",
                     "transforms":{
                         "emission_rate": 0.006879832936086124,
-                        "efficiency_rate": 0.72289814,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.051727,
                         "capture_rate": 0.17416840222407487
                     },
@@ -241,7 +241,7 @@
                     "id": "NE_Large_SMR_wCCS_96pct",
                     "transforms":{
                         "emission_rate": 0.006879832936086124,
-                        "efficiency_rate": 0.72289814,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.051727,
                         "capture_rate": 0.17416840222407487
                     },

--- a/ExampleSystems/eastern_us_three_zones/assets/naturalgas_power.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/naturalgas_power.json
@@ -42,7 +42,7 @@
                     "id": "MIDAT_natural_gas_fired_combined_cycle_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.444520797
+                        "fuel_consumption": 2.249613533
                     },
                     "edges":{
                         "elec_edge": {
@@ -55,7 +55,7 @@
                             "variable_om_cost": 4.415,
                             "capacity_size": 125.825,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -71,7 +71,7 @@
                     "id": "MIDAT_natural_gas_fired_combined_cycle_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.499362159
+                        "fuel_consumption": 2.002554621
                     },
                     "edges":{
                         "elec_edge": {
@@ -84,7 +84,7 @@
                             "variable_om_cost": 3.452,
                             "capacity_size": 588.943,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -100,7 +100,7 @@
                     "id": "MIDAT_natural_gas_fired_combined_cycle_3",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.277884326
+                        "fuel_consumption": 3.598619669
                     },
                     "edges":{
                         "elec_edge": {
@@ -113,7 +113,7 @@
                             "variable_om_cost": 3.505,
                             "capacity_size": 212.212,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -129,7 +129,7 @@
                     "id": "MIDAT_natural_gas_fired_combined_cycle_4",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.475891441
+                        "fuel_consumption": 2.101319572
                     },
                     "edges":{
                         "elec_edge": {
@@ -142,7 +142,7 @@
                             "variable_om_cost": 3.504,
                             "capacity_size": 614.803,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -158,7 +158,7 @@
                     "id": "MIDAT_natural_gas_fired_combustion_turbine_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.29037032
+                        "fuel_consumption": 3.443878144
                     },
                     "edges":{
                         "elec_edge": {
@@ -171,7 +171,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 116.07,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -187,7 +187,7 @@
                     "id": "MIDAT_natural_gas_fired_combustion_turbine_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.332859393
+                        "fuel_consumption": 3.004271539
                     },
                     "edges":{
                         "elec_edge": {
@@ -200,7 +200,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 14.994,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -216,7 +216,7 @@
                     "id": "NE_natural_gas_fired_combined_cycle_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.398103096
+                        "fuel_consumption": 2.511912141
                     },
                     "edges":{
                         "elec_edge": {
@@ -229,7 +229,7 @@
                             "variable_om_cost": 4.415,
                             "capacity_size": 127.492,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -245,7 +245,7 @@
                     "id": "NE_natural_gas_fired_combined_cycle_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.44527491
+                        "fuel_consumption": 2.245803609
                     },
                     "edges":{
                         "elec_edge": {
@@ -258,7 +258,7 @@
                             "variable_om_cost": 3.488,
                             "capacity_size": 442.19,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -274,7 +274,7 @@
                     "id": "NE_natural_gas_fired_combined_cycle_3",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.17162827
+                        "fuel_consumption": 5.826545943
                     },
                     "edges":{
                         "elec_edge": {
@@ -287,7 +287,7 @@
                             "variable_om_cost": 4.415,
                             "capacity_size": 19.5,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -303,7 +303,7 @@
                     "id": "NE_natural_gas_fired_combined_cycle_4",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.17162827
+                        "fuel_consumption": 0
                     },
                     "edges":{
                         "elec_edge": {
@@ -316,7 +316,7 @@
                             "variable_om_cost": 3.504,
                             "capacity_size": 148,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -332,7 +332,7 @@
                     "id": "NE_natural_gas_fired_combustion_turbine_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.301106745
+                        "fuel_consumption": 3.321081365
                     },
                     "edges":{
                         "elec_edge": {
@@ -345,7 +345,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 24.793,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -361,7 +361,7 @@
                     "id": "NE_natural_gas_fired_combustion_turbine_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.338204147
+                        "fuel_consumption": 3.321081365
                     },
                     "edges":{
                         "elec_edge": {
@@ -374,7 +374,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 80.731,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -390,7 +390,7 @@
                     "id": "SE_natural_gas_fired_combined_cycle_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.469022905
+                        "fuel_consumption": 2.132092034
                     },
                     "edges":{
                         "elec_edge": {
@@ -403,7 +403,7 @@
                             "variable_om_cost": 3.504,
                             "capacity_size": 504.206,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -419,7 +419,7 @@
                     "id": "SE_natural_gas_fired_combined_cycle_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.44113014
+                        "fuel_consumption": 2.266904726
                     },
                     "edges":{
                         "elec_edge": {
@@ -432,7 +432,7 @@
                             "variable_om_cost": 4.415,
                             "capacity_size": 185.5,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -448,7 +448,7 @@
                     "id": "SE_natural_gas_fired_combined_cycle_3",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.489617109
+                        "fuel_consumption": 2.042412287
                     },
                     "edges":{
                         "elec_edge": {
@@ -461,7 +461,7 @@
                             "variable_om_cost": 3.455,
                             "capacity_size": 711.322,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -477,7 +477,7 @@
                     "id": "SE_natural_gas_fired_combined_cycle_4",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.33337974
+                        "fuel_consumption": 2.999582401
                     },
                     "edges":{
                         "elec_edge": {
@@ -490,7 +490,7 @@
                             "variable_om_cost": 3.493,
                             "capacity_size": 507.375,
                             "startup_cost": 89.34,
-                            "startup_fuel": 0.58614214,                            
+                            "startup_fuel_consumption": 0.58614214,                            
                             "min_up_time": 6,
                             "min_down_time": 6,
                             "ramp_up_fraction": 0.64,
@@ -506,7 +506,7 @@
                     "id": "SE_natural_gas_fired_combustion_turbine_1",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.306488964
+                        "fuel_consumption": 3.262760222
                     },
                     "edges":{
                         "elec_edge": {
@@ -519,7 +519,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 138.523,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -535,7 +535,7 @@
                     "id": "SE_natural_gas_fired_combustion_turbine_2",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.331083023
+                        "fuel_consumption": 3.020390447
                     },
                     "edges":{
                         "elec_edge": {
@@ -548,7 +548,7 @@
                             "variable_om_cost": 5.071,
                             "capacity_size": 22.039,
                             "startup_cost": 115.842,
-                            "startup_fuel": 1.025748745,                            
+                            "startup_fuel_consumption": 1.025748745,                            
                             "min_up_time": 1,
                             "min_down_time": 1,
                             "ramp_up_fraction": 0.64,
@@ -564,7 +564,7 @@
                     "id": "SE_naturalgas_ccavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.53624731
+                        "fuel_consumption": 1.864811218
                     },
                     "edges":{
                         "elec_edge": {
@@ -577,7 +577,7 @@
                             "variable_om_cost": 1.74,
                             "capacity_size": 573,
                             "startup_cost": 61,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -593,7 +593,7 @@
                     "id": "SE_naturalgas_ctavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.351151758
+                        "fuel_consumption": 2.847771587
                     },
                     "edges":{
                         "elec_edge": {
@@ -606,7 +606,7 @@
                             "variable_om_cost": 4.94,
                             "capacity_size": 237,
                             "startup_cost": 140,
-                            "startup_fuel": 0.055683503,                            
+                            "startup_fuel_consumption": 0.055683503,                            
                             "min_up_time": 0,
                             "min_down_time": 0,
                             "ramp_up_fraction": 1,
@@ -622,7 +622,7 @@
                     "id": "MIDAT_naturalgas_ccavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.53624731
+                        "fuel_consumption": 1.864811218
                     },
                     "edges":{
                         "elec_edge": {
@@ -635,7 +635,7 @@
                             "variable_om_cost": 1.74,
                             "capacity_size": 573,
                             "startup_cost": 61,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -651,7 +651,7 @@
                     "id": "MIDAT_naturalgas_ctavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.351151758
+                        "fuel_consumption": 2.847771587
                     },
                     "edges":{
                         "elec_edge": {
@@ -664,7 +664,7 @@
                             "variable_om_cost": 4.94,
                             "capacity_size": 237,
                             "startup_cost": 140,
-                            "startup_fuel": 0.055683503,                            
+                            "startup_fuel_consumption": 0.055683503,                            
                             "min_up_time": 0,
                             "min_down_time": 0,
                             "ramp_up_fraction": 1,
@@ -680,7 +680,7 @@
                     "id": "NE_naturalgas_ccavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.53624731
+                        "fuel_consumption": 1.864811218
                     },
                     "edges":{
                         "elec_edge": {
@@ -693,7 +693,7 @@
                             "variable_om_cost": 1.74,
                             "capacity_size": 573,
                             "startup_cost": 61,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -709,7 +709,7 @@
                     "id": "NE_naturalgas_ctavgcf_moderate_0",
                     "transforms":{
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.351151758
+                        "fuel_consumption": 2.847771587
                     },
                     "edges":{
                         "elec_edge": {
@@ -722,7 +722,7 @@
                             "variable_om_cost": 4.94,
                             "capacity_size": 237,
                             "startup_cost": 140,
-                            "startup_fuel": 0.055683503,                            
+                            "startup_fuel_consumption": 0.055683503,                            
                             "min_up_time": 0,
                             "min_down_time": 0,
                             "ramp_up_fraction": 1,

--- a/ExampleSystems/eastern_us_three_zones/assets/naturalgas_power_ccs.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/naturalgas_power_ccs.json
@@ -51,7 +51,7 @@
                 {
                     "id": "SE_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.09809579,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -64,7 +64,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -79,7 +79,7 @@
                 {
                     "id": "MIDAT_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.09809579,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -92,7 +92,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -107,7 +107,7 @@
                 {
                     "id": "NE_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.09809579,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -120,7 +120,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,

--- a/ExampleSystems/eastern_us_three_zones/assets/nuclear_power.json
+++ b/ExampleSystems/eastern_us_three_zones/assets/nuclear_power.json
@@ -43,7 +43,7 @@
                 {
                     "id": "SE_nuclear_1",
                     "transforms":{
-                        "efficiency_rate": 0.326333362
+                        "fuel_consumption": 3.064351108
                     },
                     "edges":{
                         "elec_edge": {
@@ -60,14 +60,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "SE_nuclear_2",
                     "transforms":{
-                        "efficiency_rate": 0.370482262
+                        "fuel_consumption": 2.699184555
                     },
                     "edges":{
                         "elec_edge": {
@@ -84,14 +84,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "NE_nuclear_1",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -108,14 +108,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "NE_nuclear_2",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -132,14 +132,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "MIDAT_nuclear_1",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -156,14 +156,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "MIDAT_nuclear_2",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -180,14 +180,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "MIDAT_nuclear_mid_0",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -205,14 +205,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "NE_nuclear_mid_0",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -230,14 +230,14 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 },
                 {
                     "id": "SE_nuclear_mid_0",
                     "transforms":{
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.064058037
                     },
                     "edges":{
                         "elec_edge": {
@@ -255,7 +255,7 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         }
                     }
                 }

--- a/src/model/assets/thermalhydrogen.jl
+++ b/src/model/assets/thermalhydrogen.jl
@@ -37,7 +37,7 @@ fuel_edge::Edge{T},co2_edge::Edge{CO2}) where T<:Commodity =
             - min_up_time: Int
             - min_down_time: Int
             - startup_cost: Float64
-            - startup_fuel: Float64
+            - startup_fuel_consumption: Float64
             - startup_fuel_balance_id: Symbol
             - constraints: Vector{AbstractTypeConstraint}
         - fuel_edge: Dict{Symbol, Any}
@@ -108,6 +108,7 @@ function make(::Type{ThermalHydrogen}, data::AbstractDict{Symbol,Any}, system::S
                 MinDownTimeConstraint(),
             ],
         )
+        h2_edge.startup_fuel_balance_id = :energy
     else
         h2_edge = Edge(
             Symbol(id, "_", h2_edge_key),
@@ -127,8 +128,6 @@ function make(::Type{ThermalHydrogen}, data::AbstractDict{Symbol,Any}, system::S
     end
 
     h2_edge.unidirectional = true;
-    h2_edge.startup_fuel_balance_id = :energy
-
     fuel_edge_key = :fuel_edge
     fuel_edge_data = process_data(data[:edges][fuel_edge_key])
     T = commodity_types()[Symbol(fuel_edge_data[:type])];
@@ -163,8 +162,8 @@ function make(::Type{ThermalHydrogen}, data::AbstractDict{Symbol,Any}, system::S
 
     thermalhydrogen_transform.balance_data = Dict(
         :energy => Dict(
-            h2_edge.id => 1.0,
-            fuel_edge.id => get(transform_data, :efficiency_rate, 1.0),
+            h2_edge.id => get(transform_data, :fuel_consumption, 1.0),
+            fuel_edge.id => 1.0,
         ),
         :electricity => Dict(
             h2_edge.id => get(transform_data, :electricity_consumption, 0.0),

--- a/src/model/assets/thermalhydrogenccs.jl
+++ b/src/model/assets/thermalhydrogenccs.jl
@@ -37,7 +37,7 @@ fuel_edge::Edge{T},co2_edge::Edge{CO2},co2_captured_edge::Edge{CO2Captured}) whe
             - min_up_time: Int
             - min_down_time: Int
             - startup_cost: Float64
-            - startup_fuel: Float64
+            - startup_fuel_consumption: Float64
             - startup_fuel_balance_id: Symbol
             - constraints: Vector{AbstractTypeConstraint}
         - fuel_edge: Dict{Symbol, Any}
@@ -115,6 +115,7 @@ function make(::Type{ThermalHydrogenCCS}, data::AbstractDict{Symbol,Any}, system
                 MinDownTimeConstraint(),
             ],
         )
+        h2_edge.startup_fuel_balance_id = :energy
     else
         h2_edge = Edge(
             Symbol(id, "_", h2_edge_key),
@@ -133,7 +134,7 @@ function make(::Type{ThermalHydrogenCCS}, data::AbstractDict{Symbol,Any}, system
         )
     end
     h2_edge.unidirectional = true;
-    h2_edge.startup_fuel_balance_id = :energy
+    
 
     fuel_edge_key = :fuel_edge
     fuel_edge_data = process_data(data[:edges][fuel_edge_key])
@@ -184,8 +185,8 @@ function make(::Type{ThermalHydrogenCCS}, data::AbstractDict{Symbol,Any}, system
 
     thermalhydrogenccs_transform.balance_data = Dict(
         :energy => Dict(
-            h2_edge.id => 1.0,
-            fuel_edge.id => get(transform_data, :efficiency_rate, 1.0),
+            h2_edge.id =>  get(transform_data, :fuel_consumption, 1.0),
+            fuel_edge.id => 1.0,
         ),
         :electricity => Dict(
             h2_edge.id => get(transform_data, :electricity_consumption, 0.0),

--- a/src/model/assets/thermalpower.jl
+++ b/src/model/assets/thermalpower.jl
@@ -44,6 +44,7 @@ function make(::Type{ThermalPower}, data::AbstractDict{Symbol,Any}, system::Syst
                 MinDownTimeConstraint(),
             ],
         )
+        elec_edge.startup_fuel_balance_id = :energy
     else
         elec_edge = Edge(
             Symbol(id, "_", elec_edge_key),
@@ -62,8 +63,7 @@ function make(::Type{ThermalPower}, data::AbstractDict{Symbol,Any}, system::Syst
         )
     end
     elec_edge.unidirectional = true;
-    elec_edge.startup_fuel_balance_id = :energy
-
+    
     fuel_edge_key = :fuel_edge
     fuel_edge_data = process_data(data[:edges][fuel_edge_key])
     T = commodity_types()[Symbol(fuel_edge_data[:type])];
@@ -98,8 +98,8 @@ function make(::Type{ThermalPower}, data::AbstractDict{Symbol,Any}, system::Syst
 
     thermal_transform.balance_data = Dict(
         :energy => Dict(
-            elec_edge.id => 1.0,
-            fuel_edge.id => get(transform_data, :efficiency_rate, 1.0),
+            elec_edge.id => get(transform_data, :fuel_consumption, 1.0),
+            fuel_edge.id => 1.0,
             co2_edge.id => 0.0,
         ),
         :emissions => Dict(

--- a/src/model/assets/thermalpowerccs.jl
+++ b/src/model/assets/thermalpowerccs.jl
@@ -44,6 +44,7 @@ function make(::Type{ThermalPowerCCS}, data::AbstractDict{Symbol,Any}, system::S
                 MinDownTimeConstraint(),
             ],
         )
+        elec_edge.startup_fuel_balance_id = :energy
     else
         elec_edge = Edge(
             Symbol(id, "_", elec_edge_key),
@@ -62,7 +63,7 @@ function make(::Type{ThermalPowerCCS}, data::AbstractDict{Symbol,Any}, system::S
         )
     end
     elec_edge.unidirectional = true;
-    elec_edge.startup_fuel_balance_id = :energy
+    
 
     fuel_edge_key = :fuel_edge
     fuel_edge_data = process_data(data[:edges][fuel_edge_key])
@@ -114,8 +115,8 @@ function make(::Type{ThermalPowerCCS}, data::AbstractDict{Symbol,Any}, system::S
 
     thermalccs_transform.balance_data = Dict(
         :energy => Dict(
-            elec_edge.id => 1.0,
-            fuel_edge.id => get(transform_data, :efficiency_rate, 1.0),
+            elec_edge.id => get(transform_data, :fuel_consumption, 1.0),
+            fuel_edge.id => 1.0,
             co2_edge.id => 0.0,
             co2_captured_edge.id => 0.0,
         ),

--- a/test/test_inputs/assets/h2gas_power_ccgt.json
+++ b/test/test_inputs/assets/h2gas_power_ccgt.json
@@ -43,7 +43,7 @@
                     "id": "MA_CCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges": {
                         "elec_edge": {
@@ -79,7 +79,7 @@
                     "id": "CT_CCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges": {
                         "elec_edge": {
@@ -115,7 +115,7 @@
                     "id": "ME_CCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.549644
+                        "fuel_consumption": 1.8193594399283899
                     },
                     "edges": {
                         "elec_edge": {

--- a/test/test_inputs/assets/h2gas_power_ocgt.json
+++ b/test/test_inputs/assets/h2gas_power_ocgt.json
@@ -41,7 +41,7 @@
                     "id": "MA_OCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges": {
                         "elec_edge": {
@@ -75,7 +75,7 @@
                     "id": "CT_OCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges": {
                         "elec_edge": {
@@ -109,7 +109,7 @@
                     "id": "ME_OCGT-H2",
                     "transforms": {
                         "emission_rate": 0,
-                        "efficiency_rate": 0.45353
+                        "fuel_consumption": 2.2049258042466873
                     },
                     "edges": {
                         "elec_edge": {

--- a/test/test_inputs/assets/naturalgas_h2.json
+++ b/test/test_inputs/assets/naturalgas_h2.json
@@ -49,7 +49,7 @@
                     "id": "MA_Large_SMR_Non_CCS",
                     "transforms": {
                         "emission_rate": 0.069029264,
-                        "efficiency_rate": 0.76865951,
+                        "fuel_consumption": 1.3009661455954666,
                         "electricity_consumption": 0.016404
                     },
                     "edges": {

--- a/test/test_inputs/assets/naturalgas_h2_ccs.json
+++ b/test/test_inputs/assets/naturalgas_h2_ccs.json
@@ -55,7 +55,7 @@
                     "id": "MA_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },
@@ -95,7 +95,7 @@
                     "id": "CT_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },
@@ -135,7 +135,7 @@
                     "id": "ME_ATR_wCCS_94pct",
                     "transforms":{
                         "emission_rate": 0.003794329,
-                        "efficiency_rate": 0.769121482,
+                        "fuel_consumption": 1.300184721664035,
                         "electricity_consumption": 0.101574,
                         "capture_rate": 0.065193472
                     },

--- a/test/test_inputs/assets/naturalgas_power_ccs.json
+++ b/test/test_inputs/assets/naturalgas_power_ccs.json
@@ -50,7 +50,7 @@
                 {
                     "id": "SE_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.098095788823403,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -63,7 +63,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -81,7 +81,7 @@
                 {
                     "id": "MIDAT_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.098095788823403,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -94,7 +94,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,
@@ -112,7 +112,7 @@
                 {
                     "id": "NE_naturalgas_ccccsavgcf_conservative_0",
                     "transforms": {                    
-                    "efficiency_rate": 0.476622662,
+                    "fuel_consumption": 2.098095788823403,
                     "emission_rate": 0.018104824,
                     "capture_rate": 0.162943412
                     },
@@ -125,7 +125,7 @@
                             "variable_om_cost": 5.73,
                             "capacity_size": 377,
                             "startup_cost": 97,
-                            "startup_fuel": 0.058614214,                            
+                            "startup_fuel_consumption": 0.058614214,                            
                             "min_up_time": 4,
                             "min_down_time": 4,
                             "ramp_up_fraction": 1,

--- a/test/test_inputs/assets/nuclear_power.json
+++ b/test/test_inputs/assets/nuclear_power.json
@@ -42,7 +42,7 @@
                 {
                     "id": "MA_nuclear_1",
                     "transforms": {
-                        "efficiency_rate": 0.326333362
+                        "fuel_consumption": 3.0643511097709952
                     },
                     "edges": {
                         "elec_edge": {
@@ -59,7 +59,7 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         },
                         "co2_edge": {
                             "end_vertex": "co2_MA"
@@ -69,7 +69,7 @@
                 {
                     "id": "CT_nuclear_mid_0",
                     "transforms": {
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.0643511097709952
                     },
                     "edges": {
                         "elec_edge": {
@@ -87,7 +87,7 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         },
                         "co2_edge": {
                             "end_vertex": "co2_CT"
@@ -97,7 +97,7 @@
                 {
                     "id": "ME_nuclear_mid_0",
                     "transforms": {
-                        "efficiency_rate": 0.326364575
+                        "fuel_consumption": 3.0643511097709952
                     },
                     "edges": {
                         "elec_edge": {
@@ -115,7 +115,7 @@
                             "min_down_time": 36,
                             "ramp_up_fraction": 0.25,
                             "ramp_down_fraction": 0.25,
-                            "startup_fuel": 0.0
+                            "startup_fuel_consumption": 0.0
                         },
                         "co2_edge": {
                             "end_vertex": "co2_ME"

--- a/test/test_inputs/assets/thermal.json
+++ b/test/test_inputs/assets/thermal.json
@@ -22,7 +22,7 @@
                         "ramp_up_fraction": 0.64,
                         "ramp_down_fraction": 0.64,
                         "startup_cost": 91,
-                        "startup_fuel": 0.58614214,
+                        "startup_fuel_consumption": 0.58614214,
                         "existing_capacity": 0,
                         "capacity_size": 250,
                         "investment_cost": 65400,
@@ -52,7 +52,7 @@
                     "nodes": {},
                     "transforms": {
                         "emission_rate": 0.181048235160161,
-                        "efficiency_rate": 0.444520797
+                        "fuel_consumption": 2.2496135315801657
                     },
                     "edges": {
                         "elec_edge": {
@@ -73,7 +73,7 @@
                     "id": "ng_CT",
                     "nodes": {},
                     "transforms": {
-                        "efficiency_rate": 0.499362159,
+                        "fuel_consumption": 2.002554622886433,
                         "emission_rate": 0.181048235160161
                     },
                     "edges": {
@@ -95,7 +95,7 @@
                     "id": "ng_ME",
                     "nodes": {},
                     "transforms": {
-                        "efficiency_rate": 0.475891441,
+                        "fuel_consumption": 2.1013195738479356,
                         "emission_rate": 0.181048235160161
                     },
                     "edges": {

--- a/test/test_inputs/run.jl
+++ b/test/test_inputs/run.jl
@@ -1,6 +1,12 @@
 using MacroEnergy
 using Gurobi
 
-(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer);
+#(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer);
 
 println()
+
+system = MacroEnergy.load_system(@__DIR__)
+model = MacroEnergy.generate_model(system)
+MacroEnergy.set_optimizer(model, Gurobi.Optimizer)
+MacroEnergy.optimize!(model)
+macro_objval = MacroEnergy.objective_value(model)

--- a/test/test_inputs/system_data_true.json
+++ b/test/test_inputs/system_data_true.json
@@ -12048,7 +12048,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 27300,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -12647,9 +12647,9 @@
                             "MA_CCGT-H2_elec_edge": 0
                         },
                         "energy": {
-                            "MA_CCGT-H2_fuel_edge": 0.549644,
+                            "MA_CCGT-H2_fuel_edge": 1,
                             "MA_CCGT-H2_co2_edge": 0,
-                            "MA_CCGT-H2_elec_edge": 1
+                            "MA_CCGT-H2_elec_edge": 1.8193594399283899
                         }
                     },
                     "id": "MA_CCGT-H2_transforms",
@@ -12677,7 +12677,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 27300,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -13276,8 +13276,8 @@
                             "CT_CCGT-H2_co2_edge": 1
                         },
                         "energy": {
-                            "CT_CCGT-H2_elec_edge": 1,
-                            "CT_CCGT-H2_fuel_edge": 0.549644,
+                            "CT_CCGT-H2_elec_edge": 1.8193594399283899,
+                            "CT_CCGT-H2_fuel_edge": 1,
                             "CT_CCGT-H2_co2_edge": 0
                         }
                     },
@@ -13306,7 +13306,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 27300,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -13905,9 +13905,9 @@
                             "ME_CCGT-H2_fuel_edge": 0
                         },
                         "energy": {
-                            "ME_CCGT-H2_elec_edge": 1,
+                            "ME_CCGT-H2_elec_edge": 1.8193594399283899,
                             "ME_CCGT-H2_co2_edge": 0,
-                            "ME_CCGT-H2_fuel_edge": 0.549644
+                            "ME_CCGT-H2_fuel_edge": 1
                         }
                     },
                     "id": "ME_CCGT-H2_transforms",
@@ -13935,7 +13935,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 20900,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -14532,8 +14532,8 @@
                             "MA_OCGT-H2_co2_edge": 1
                         },
                         "energy": {
-                            "MA_OCGT-H2_elec_edge": 1,
-                            "MA_OCGT-H2_fuel_edge": 0.45353,
+                            "MA_OCGT-H2_elec_edge": 2.2049258042466873,
+                            "MA_OCGT-H2_fuel_edge": 1,
                             "MA_OCGT-H2_co2_edge": 0
                         }
                     },
@@ -14562,7 +14562,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 20900,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -15159,8 +15159,8 @@
                             "CT_OCGT-H2_co2_edge": 1
                         },
                         "energy": {
-                            "CT_OCGT-H2_elec_edge": 1,
-                            "CT_OCGT-H2_fuel_edge": 0.45353,
+                            "CT_OCGT-H2_elec_edge": 2.2049258042466873,
+                            "CT_OCGT-H2_fuel_edge": 1,
                             "CT_OCGT-H2_co2_edge": 0
                         }
                     },
@@ -15189,7 +15189,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 20900,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -15787,8 +15787,8 @@
                         },
                         "energy": {
                             "ME_OCGT-H2_co2_edge": 0,
-                            "ME_OCGT-H2_elec_edge": 1,
-                            "ME_OCGT-H2_fuel_edge": 0.45353
+                            "ME_OCGT-H2_elec_edge": 2.2049258042466873,
+                            "ME_OCGT-H2_fuel_edge": 1
                         }
                     },
                     "id": "ME_OCGT-H2_transforms",
@@ -22776,7 +22776,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 13685.61723,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -23347,8 +23347,8 @@
                             "MA_Large_SMR_Non_CCS_fuel_edge": 0.069029264
                         },
                         "energy": {
-                            "MA_Large_SMR_Non_CCS_h2_edge": 1,
-                            "MA_Large_SMR_Non_CCS_fuel_edge": 0.76865951
+                            "MA_Large_SMR_Non_CCS_h2_edge": 1.3009661455954666,
+                            "MA_Large_SMR_Non_CCS_fuel_edge": 1
                         },
                         "electricity": {
                             "MA_Large_SMR_Non_CCS_h2_edge": 0.016404,
@@ -23434,7 +23434,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 0,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -24092,7 +24092,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 0,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -24750,7 +24750,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 23292.27286,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -25348,8 +25348,8 @@
                             "MA_ATR_wCCS_94pct_co2_edge": 1
                         },
                         "energy": {
-                            "MA_ATR_wCCS_94pct_fuel_edge": 0.769121482,
-                            "MA_ATR_wCCS_94pct_h2_edge": 1
+                            "MA_ATR_wCCS_94pct_fuel_edge": 1,
+                            "MA_ATR_wCCS_94pct_h2_edge": 1.300184721664035
                         },
                         "electricity": {
                             "MA_ATR_wCCS_94pct_elec_edge": 1,
@@ -25439,7 +25439,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 23292.27286,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -26037,8 +26037,8 @@
                             "CT_ATR_wCCS_94pct_co2_edge": 1
                         },
                         "energy": {
-                            "CT_ATR_wCCS_94pct_h2_edge": 1,
-                            "CT_ATR_wCCS_94pct_fuel_edge": 0.769121482
+                            "CT_ATR_wCCS_94pct_h2_edge": 1.300184721664035,
+                            "CT_ATR_wCCS_94pct_fuel_edge": 1
                         },
                         "electricity": {
                             "CT_ATR_wCCS_94pct_h2_edge": 0.101574,
@@ -26128,7 +26128,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 23292.27286,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "availability": [
                             0.9,
                             0.9,
@@ -26726,8 +26726,8 @@
                             "ME_ATR_wCCS_94pct_fuel_edge": 0.003794329
                         },
                         "energy": {
-                            "ME_ATR_wCCS_94pct_h2_edge": 1,
-                            "ME_ATR_wCCS_94pct_fuel_edge": 0.769121482
+                            "ME_ATR_wCCS_94pct_h2_edge": 1.300184721664035,
+                            "ME_ATR_wCCS_94pct_fuel_edge": 1
                         },
                         "electricity": {
                             "ME_ATR_wCCS_94pct_h2_edge": 0.101574,
@@ -26763,7 +26763,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 65100,
-                        "startup_fuel": 0.058614214,
+                        "startup_fuel_consumption": 0.058614214,
                         "existing_capacity": 0,
                         "min_up_time": 4,
                         "capacity_size": 377,
@@ -26884,8 +26884,8 @@
                             "SE_naturalgas_ccccsavgcf_conservative_0_co2_captured_edge": 0
                         },
                         "energy": {
-                            "SE_naturalgas_ccccsavgcf_conservative_0_elec_edge": 1,
-                            "SE_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 0.476622662,
+                            "SE_naturalgas_ccccsavgcf_conservative_0_elec_edge": 2.098095788823403,
+                            "SE_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 1,
                             "SE_naturalgas_ccccsavgcf_conservative_0_co2_edge": 0,
                             "SE_naturalgas_ccccsavgcf_conservative_0_co2_captured_edge": 0
                         },
@@ -26921,7 +26921,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 65100,
-                        "startup_fuel": 0.058614214,
+                        "startup_fuel_consumption": 0.058614214,
                         "existing_capacity": 0,
                         "min_up_time": 4,
                         "capacity_size": 377,
@@ -27043,8 +27043,8 @@
                         },
                         "energy": {
                             "MIDAT_naturalgas_ccccsavgcf_conservative_0_co2_captured_edge": 0,
-                            "MIDAT_naturalgas_ccccsavgcf_conservative_0_elec_edge": 1,
-                            "MIDAT_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 0.476622662,
+                            "MIDAT_naturalgas_ccccsavgcf_conservative_0_elec_edge": 2.098095788823403,
+                            "MIDAT_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 1,
                             "MIDAT_naturalgas_ccccsavgcf_conservative_0_co2_edge": 0
                         },
                         "capture": {
@@ -27079,7 +27079,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 65100,
-                        "startup_fuel": 0.058614214,
+                        "startup_fuel_consumption": 0.058614214,
                         "existing_capacity": 0,
                         "min_up_time": 4,
                         "capacity_size": 377,
@@ -27201,9 +27201,9 @@
                         },
                         "energy": {
                             "NE_naturalgas_ccccsavgcf_conservative_0_co2_captured_edge": 0,
-                            "NE_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 0.476622662,
+                            "NE_naturalgas_ccccsavgcf_conservative_0_fuel_edge": 1,
                             "NE_naturalgas_ccccsavgcf_conservative_0_co2_edge": 0,
-                            "NE_naturalgas_ccccsavgcf_conservative_0_elec_edge": 1
+                            "NE_naturalgas_ccccsavgcf_conservative_0_elec_edge": 2.098095788823403
                         },
                         "capture": {
                             "NE_naturalgas_ccccsavgcf_conservative_0_co2_captured_edge": 1,
@@ -27237,7 +27237,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 199087.824,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "existing_capacity": 33632.288,
                         "min_up_time": 36,
                         "capacity_size": 1051.009,
@@ -27330,8 +27330,8 @@
                             "MA_nuclear_1_co2_edge": 1
                         },
                         "energy": {
-                            "MA_nuclear_1_fuel_edge": 0.326333362,
-                            "MA_nuclear_1_elec_edge": 1,
+                            "MA_nuclear_1_fuel_edge": 1,
+                            "MA_nuclear_1_elec_edge": 3.0643511097709952,
                             "MA_nuclear_1_co2_edge": 0
                         }
                     },
@@ -27360,7 +27360,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 144972.332,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "existing_capacity": 0,
                         "min_up_time": 36,
                         "capacity_size": 1000,
@@ -27453,8 +27453,8 @@
                             "CT_nuclear_mid_0_co2_edge": 1
                         },
                         "energy": {
-                            "CT_nuclear_mid_0_fuel_edge": 0.326364575,
-                            "CT_nuclear_mid_0_elec_edge": 1,
+                            "CT_nuclear_mid_0_fuel_edge": 1,
+                            "CT_nuclear_mid_0_elec_edge": 3.0640580400002055,
                             "CT_nuclear_mid_0_co2_edge": 0
                         }
                     },
@@ -27483,7 +27483,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 144972.332,
-                        "startup_fuel": 0,
+                        "startup_fuel_consumption": 0,
                         "existing_capacity": 0,
                         "min_up_time": 36,
                         "capacity_size": 1000,
@@ -27576,8 +27576,8 @@
                             "ME_nuclear_mid_0_co2_edge": 1
                         },
                         "energy": {
-                            "ME_nuclear_mid_0_fuel_edge": 0.326364575,
-                            "ME_nuclear_mid_0_elec_edge": 1,
+                            "ME_nuclear_mid_0_fuel_edge": 1,
+                            "ME_nuclear_mid_0_elec_edge": 3.0640580400002055,
                             "ME_nuclear_mid_0_co2_edge": 0
                         }
                     },
@@ -27995,7 +27995,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 10287,
-                        "startup_fuel": 0.58614214,
+                        "startup_fuel_consumption": 0.58614214,
                         "existing_capacity": 0,
                         "min_up_time": 6,
                         "capacity_size": 250,
@@ -28088,7 +28088,7 @@
                             "ng_MA_fuel_edge": 0.181048235160161
                         },
                         "energy": {
-                            "ng_MA_elec_edge": 1,
+                            "ng_MA_elec_edge": 2.2496135315801657,
                             "ng_MA_co2_edge": 0,
                             "ng_MA_fuel_edge": 0.444520797
                         }
@@ -28118,7 +28118,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 9698,
-                        "startup_fuel": 0.58614214,
+                        "startup_fuel_consumption": 0.58614214,
                         "existing_capacity": 0,
                         "min_up_time": 6,
                         "capacity_size": 250,
@@ -28211,9 +28211,9 @@
                             "ng_CT_elec_edge": 0
                         },
                         "energy": {
-                            "ng_CT_fuel_edge": 0.499362159,
+                            "ng_CT_fuel_edge": 1,
                             "ng_CT_co2_edge": 0,
-                            "ng_CT_elec_edge": 1
+                            "ng_CT_elec_edge": 2.002554622886433
                         }
                     },
                     "id": "ng_CT_transforms",
@@ -28241,7 +28241,7 @@
                         "max_capacity": "Inf",
                         "startup_fuel_balance_id": "energy",
                         "fixed_om_cost": 16291,
-                        "startup_fuel": 0.58614214,
+                        "startup_fuel_consumption": 0.58614214,
                         "existing_capacity": 0,
                         "min_up_time": 6,
                         "capacity_size": 250,
@@ -28335,8 +28335,8 @@
                         },
                         "energy": {
                             "ng_ME_co2_edge": 0,
-                            "ng_ME_elec_edge": 1,
-                            "ng_ME_fuel_edge": 0.475891441
+                            "ng_ME_elec_edge": 2.1013195738479356,
+                            "ng_ME_fuel_edge": 1
                         }
                     },
                     "id": "ng_ME_transforms",

--- a/test/test_workflow.jl
+++ b/test/test_workflow.jl
@@ -43,7 +43,7 @@ include("test_timedata.jl")
 const test_path = joinpath(@__DIR__, "test_inputs")
 const system_data_true_path = joinpath(@__DIR__, "test_inputs/system_data_true.json")
 const optim = is_gurobi_available() ? Gurobi.Optimizer : HiGHS.Optimizer
-const obj_true = 6.238270617683867e10
+const obj_true = 6.2353192538993225e10
 
 function test_configure_settings(data::NamedTuple, data_true::T) where {T<:JSON3.Object}
     @test data.ConstraintScaling == data_true.ConstraintScaling
@@ -131,7 +131,7 @@ function test_load(e_in::EdgeWithUC{T}, e_true::S) where {T<:Commodity,S<:JSON3.
     @test e_in.min_up_time == get(e_true, :min_up_time, 0)
     @test e_in.min_down_time == get(e_true, :min_down_time, 0)
     @test e_in.startup_cost == get(e_true, :startup_cost, 0.0)
-    @test e_in.startup_fuel == get(e_true, :startup_fuel, 0.0)
+    @test e_in.startup_fuel_consumption == get(e_true, :startup_fuel_consumption, 0.0)
     @test e_in.startup_fuel_balance_id ==
           Symbol(get(e_true, :startup_fuel_balance_id, "node"))
     @test e_in.ucommit == get(e_true, :ucommit, Vector{VariableRef}())


### PR DESCRIPTION
This PR fixes a bug in the computation of startup fuel consumption for thermal resources. This was causing small errors (<0.1%) in the final total system cost.

For thermal generators (both power and hydrogen) we now explicitly require a parameter called "fuel_consumption" which expresses the amount of MWh-fuel needed to generate 1 MWh of output. For example, for a natural gas power plant, this is:

`fuel_consumption = conv_mmbtu_to_mwh * heat_rate_mmbtu_per_mwh`

where  `conv_mmbtu_to_mwh = 0.29307107`