### PR TITLE
Revert `ci.yml` to run on github hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name}}
-    runs-on: self-hosted
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name}}
+    runs-on: ${{ matrix.os }}
     strategy: 
       fail-fast: false
       matrix:
@@ -18,6 +18,8 @@ jobs:
           - "1.9" 
           - '1'  # latest stable Julia release (Linux)
           # - 'nightly'
+        os:
+          - ubuntu-latest
         arch:
           - x64
         # include:
@@ -33,8 +35,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
-      - name: Run tests 
-        run: salloc -N 1 -n 1 -t 0:20:00 bash -c "module load gurobi/12.0.0; julia --color=yes --project=${{ github.workspace }} -e 'using Pkg; Pkg.test(\"MacroEnergy\")'"
+      - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       # - uses: codecov/codecov-action@v3
       #   with:


### PR DESCRIPTION
This PR reverts the ci.yml configuration to run on github hosted runners instead of self-hosted ones. 
**Note**: self-hosted runners feature was disabled a couple of weeks ago.