### PR TITLE
Switch MacroEnergySystemsScaling -> MacroEnergyScaling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-MacroEnergySystemsScaling = "e07ba8b4-499e-4f54-a885-af58260c741f"
+MacroEnergyScaling = "824dc6dc-8db5-4e55-923f-6cabbd6cfcd5"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Parquet2 = "98572fba-bba0-415d-956f-fa77e587d26d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -29,6 +29,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [compat]
 DuckDB = "^0.10.3"
 Gurobi = "1.6.0"
+MacroEnergyScaling = "0.2.0"
 Parquet2 = "0.2.27"
 
 [extras]

--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -10,7 +10,7 @@ using HiGHS
 using Revise
 using InteractiveUtils
 using Printf: @printf
-using MacroEnergySystemsScaling
+using MacroEnergyScaling
 
 import Base: /, push!, merge!
 


### PR DESCRIPTION
We republished MacroEnergySystemsScaling as MacroEnergyScaling when he decided the naming convention. This PR switches Macro to the republished package.