### PR TITLE
Update template functions

### DIFF
--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -215,6 +215,10 @@ export AbstractAsset,
     write_costs,
     write_dataframe,
     write_flow,
-    write_results
+    write_results,
+    template_system,
+    template_node,
+    template_location,
+    template_asset
     
 end # module MacroEnergy

--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -221,5 +221,7 @@ export AbstractAsset,
     template_location,
     template_asset,
     template_subcommodity
+    asset_ids
+    asset_ids_from_dir
     
 end # module MacroEnergy

--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -219,6 +219,7 @@ export AbstractAsset,
     template_system,
     template_node,
     template_location,
-    template_asset
+    template_asset,
+    template_subcommodity
     
 end # module MacroEnergy

--- a/src/load_inputs/default_system_data.jl
+++ b/src/load_inputs/default_system_data.jl
@@ -1,7 +1,7 @@
 function default_system_data()
     return Dict{Symbol,Any}(
         :assets => Dict{Symbol,Any}(:path => "assets"),
-        :locations => Dict{Symbol,Any}(:path => "system/locations"),
+        :locations => Dict{Symbol,Any}(:path => "system/locations.json"),
         :nodes => Dict{Symbol,Any}(:path => "system/nodes.json"),
         :commodities => Dict{Symbol,Any}(:path => "system/commodities.json"),
         :time_data => Dict{Symbol,Any}(:path => "system/time_data.json"),

--- a/src/model/assets/battery.jl
+++ b/src/model/assets/battery.jl
@@ -14,7 +14,7 @@ function default_data(t::Type{Battery}, id=missing, style="full")
 end
 
 function full_default_data(::Type{Battery}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :storage => @storage_data(
             :commodity => "Electricity",
@@ -47,7 +47,7 @@ function full_default_data(::Type{Battery}, id=missing)
 end
 
 function simple_default_data(::Type{Battery}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :storage_can_expand => true,

--- a/src/model/assets/beccselectricity.jl
+++ b/src/model/assets/beccselectricity.jl
@@ -17,7 +17,7 @@ function default_data(t::Type{BECCSElectricity}, id=missing, style="full")
 end
 
 function full_default_data(::Type{BECCSElectricity}, id=missing,)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Biomass",
@@ -58,7 +58,7 @@ function full_default_data(::Type{BECCSElectricity}, id=missing,)
 end
 
 function simple_default_data(::Type{BECCSElectricity}, id=missing,)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/beccsgasoline.jl
+++ b/src/model/assets/beccsgasoline.jl
@@ -18,7 +18,7 @@ function default_data(t::Type{BECCSGasoline}, id=missing, style="full")
 end
 
 function full_default_data(::Type{BECCSGasoline}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Biomass",
@@ -63,7 +63,7 @@ function full_default_data(::Type{BECCSGasoline}, id=missing)
 end
 
 function simple_default_data(::Type{BECCSGasoline}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_retire => true,

--- a/src/model/assets/beccshydrogen.jl
+++ b/src/model/assets/beccshydrogen.jl
@@ -18,7 +18,7 @@ function default_data(t::Type{BECCSHydrogen}, id=missing, style="full")
 end
 
 function full_default_data(::Type{BECCSHydrogen}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Biomass",
@@ -63,7 +63,7 @@ function full_default_data(::Type{BECCSHydrogen}, id=missing)
 end
 
 function simple_default_data(::Type{BECCSHydrogen}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/beccsliquidfuels.jl
+++ b/src/model/assets/beccsliquidfuels.jl
@@ -21,7 +21,7 @@ function default_data(t::Type{BECCSLiquidFuels}, id=missing, style="full")
 end
 
 function full_default_data(::Type{BECCSLiquidFuels}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Biomass",
@@ -78,7 +78,7 @@ function full_default_data(::Type{BECCSLiquidFuels}, id=missing)
 end
 
 function simple_default_data(::Type{BECCSLiquidFuels}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/beccsnaturalgas.jl
+++ b/src/model/assets/beccsnaturalgas.jl
@@ -18,7 +18,7 @@ function default_data(t::Type{BECCSNaturalGas}, id=missing, style="full")
 end
 
 function full_default_data(::Type{BECCSNaturalGas}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Biomass",
@@ -63,7 +63,7 @@ function full_default_data(::Type{BECCSNaturalGas}, id=missing)
 end
 
 function simple_default_data(::Type{BECCSNaturalGas}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/co2injection.jl
+++ b/src/model/assets/co2injection.jl
@@ -14,7 +14,7 @@ function default_data(t::Type{CO2Injection}, id=missing, style="full")
 end
 
 function full_default_data(::Type{CO2Injection}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         id => id,
         :transforms => @transform_data(
             :constraints => Dict{Symbol,Bool}(
@@ -41,7 +41,7 @@ function full_default_data(::Type{CO2Injection}, id=missing)
 end
 
 function simple_default_data(::Type{CO2Injection}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => false,

--- a/src/model/assets/electricdac.jl
+++ b/src/model/assets/electricdac.jl
@@ -15,7 +15,7 @@ function default_data(t::Type{ElectricDAC}, id=missing, style="full")
 end
 
 function full_default_data(::Type{ElectricDAC}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -46,7 +46,7 @@ function full_default_data(::Type{ElectricDAC}, id=missing)
 end
 
 function simple_default_data(::Type{ElectricDAC}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/electrolyzer.jl
+++ b/src/model/assets/electrolyzer.jl
@@ -14,7 +14,7 @@ function default_data(t::Type{Electrolyzer}, id=missing, style="full")
 end
 
 function full_default_data(::Type{Electrolyzer}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -42,7 +42,7 @@ function full_default_data(::Type{Electrolyzer}, id=missing)
 end
 
 function simple_default_data(::Type{Electrolyzer}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/fossilfuelsupstream.jl
+++ b/src/model/assets/fossilfuelsupstream.jl
@@ -33,7 +33,7 @@ function default_data(t::Type{FossilFuelsUpstream}, id=missing, style="full")
 end
     
 function full_default_data(::Type{FossilFuelsUpstream}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "LiquidFuels",
@@ -58,7 +58,7 @@ function full_default_data(::Type{FossilFuelsUpstream}, id=missing)
 end
 
 function simple_default_data(::Type{FossilFuelsUpstream}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :emission_rate => 0.0,

--- a/src/model/assets/fossilfuelsupstream.jl
+++ b/src/model/assets/fossilfuelsupstream.jl
@@ -68,6 +68,25 @@ function simple_default_data(::Type{FossilFuelsUpstream}, id=missing)
     )
 end
 
+function set_commodity!(::Type{FossilFuelsUpstream}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fossil_fuel_edge, :fuel_edge, :co2_edge]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :fossil_fuel_commodity)
+        data[:fossil_fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+end
+
 function make(asset_type::Type{FossilFuelsUpstream}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/fuelcell.jl
+++ b/src/model/assets/fuelcell.jl
@@ -14,7 +14,7 @@ function default_data(t::Type{FuelCell}, id=missing, style="full")
 end
 
 function full_default_data(::Type{FuelCell}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -41,7 +41,7 @@ function full_default_data(::Type{FuelCell}, id=missing)
 end
 
 function simple_default_data(::Type{FuelCell}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/fuelsenduse.jl
+++ b/src/model/assets/fuelsenduse.jl
@@ -18,7 +18,7 @@ function default_data(t::Type{FuelsEndUse}, id=missing, style="full")
 end
 
 function full_default_data(::Type{FuelsEndUse}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "LiquidFuels",
@@ -44,7 +44,7 @@ function full_default_data(::Type{FuelsEndUse}, id=missing)
 end
 
 function simple_default_data(::Type{FuelsEndUse}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :co2_sink => missing,

--- a/src/model/assets/fuelsenduse.jl
+++ b/src/model/assets/fuelsenduse.jl
@@ -56,6 +56,26 @@ function simple_default_data(::Type{FuelsEndUse}, id=missing)
     )
 end
 
+function set_commodity!(::Type{FuelsEndUse}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fuel_edge, :fuel_demand_edge,]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :fuel_demand_commodity)
+        data[:fuel_demand_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+    return nothing
+end
+
 function make(asset_type::Type{FuelsEndUse}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/gasstorage.jl
+++ b/src/model/assets/gasstorage.jl
@@ -80,6 +80,7 @@ function simple_default_data(::Type{GasStorage}, id=missing)
     return Dict{Symbol,Any}(
         :id => id,
         :location => missing,
+        :storage_commodity => missing,
         :timedata => "Electricity",
         :storage_can_expand => true,
         :storage_can_retire => true,
@@ -102,6 +103,33 @@ function simple_default_data(::Type{GasStorage}, id=missing)
         :charge_electricity_consumption => 0.0,
         :discharge_electricity_consumption => 0.0,
     )
+end
+
+function set_commodity!(::Type{GasStorage}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [
+        :charge_edge,
+        :discharge_edge,
+        :external_charge_edge,
+        :external_discharge_edge,
+    ]
+    if haskey(data, :storage_commodity)
+        data[:commodity] = string(commodity)
+    end
+    if haskey(data, :storage)
+        if haskey(data[:storage], :commodity)
+            data[:storage][:commodity] = string(commodity)
+        end
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+    return nothing
 end
 
 function make(asset_type::Type{GasStorage}, data::AbstractDict{Symbol,Any}, system::System)

--- a/src/model/assets/gasstorage.jl
+++ b/src/model/assets/gasstorage.jl
@@ -23,7 +23,7 @@ function default_data(t::Type{GasStorage}, id=missing, style="full")
 end
 
 function full_default_data(::Type{GasStorage}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -77,7 +77,7 @@ function full_default_data(::Type{GasStorage}, id=missing)
 end
 
 function simple_default_data(::Type{GasStorage}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :storage_commodity => missing,
@@ -113,7 +113,7 @@ function set_commodity!(::Type{GasStorage}, commodity::Type{<:Commodity}, data::
         :external_discharge_edge,
     ]
     if haskey(data, :storage_commodity)
-        data[:commodity] = string(commodity)
+        data[:storage_commodity] = string(commodity)
     end
     if haskey(data, :storage)
         if haskey(data[:storage], :commodity)

--- a/src/model/assets/hydrores.jl
+++ b/src/model/assets/hydrores.jl
@@ -15,7 +15,7 @@ function default_data(t::Type{HydroRes}, id=missing, style="full")
 end
 
 function full_default_data(::Type{HydroRes}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :storage => @storage_data(
             :commodity => Electricity,
@@ -52,7 +52,7 @@ function full_default_data(::Type{HydroRes}, id=missing)
 end
 
 function simple_default_data(::Type{HydroRes}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :storage_can_expand => true,

--- a/src/model/assets/mustrun.jl
+++ b/src/model/assets/mustrun.jl
@@ -13,7 +13,7 @@ function default_data(t::Type{MustRun}, id=missing, style="full")
 end
 
 function full_default_data(::Type{MustRun}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -36,7 +36,7 @@ function full_default_data(::Type{MustRun}, id=missing)
 end
 
 function simple_default_data(::Type{MustRun}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/natgasdac.jl
+++ b/src/model/assets/natgasdac.jl
@@ -17,7 +17,7 @@ function default_data(t::Type{NaturalGasDAC}, id=missing, style="full")
 end
 
 function full_default_data(::Type{NaturalGasDAC}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "NaturalGas",
@@ -58,7 +58,7 @@ function full_default_data(::Type{NaturalGasDAC}, id=missing)
 end
 
 function simple_default_data(::Type{NaturalGasDAC}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/powerline.jl
+++ b/src/model/assets/powerline.jl
@@ -12,7 +12,7 @@ function default_data(t::Type{PowerLine}, id=missing, style="full")
 end
 
 function full_default_data(::Type{PowerLine}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :edges => Dict{Symbol,Any}(
             :elec_edge => @edge_data(
@@ -31,7 +31,7 @@ function full_default_data(::Type{PowerLine}, id=missing)
 end
 
 function simple_default_data(::Type{PowerLine}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/syntheticliquidfuels.jl
+++ b/src/model/assets/syntheticliquidfuels.jl
@@ -19,7 +19,7 @@ function default_data(t::Type{SyntheticLiquidFuels}, id=missing, style="full")
 end
 
 function full_default_data(::Type{SyntheticLiquidFuels}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "CO2Captured",
@@ -67,7 +67,7 @@ function full_default_data(::Type{SyntheticLiquidFuels}, id=missing)
 end
 
 function simple_default_data(::Type{SyntheticLiquidFuels}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/syntheticnaturalgas.jl
+++ b/src/model/assets/syntheticnaturalgas.jl
@@ -17,7 +17,7 @@ function default_data(t::Type{SyntheticNaturalGas}, id=missing, style="full")
 end
 
 function full_default_data(::Type{SyntheticNaturalGas}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "CO2Captured",
@@ -57,7 +57,7 @@ function full_default_data(::Type{SyntheticNaturalGas}, id=missing)
 end
 
 function simple_default_data(::Type{SyntheticNaturalGas}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/thermalhydrogen.jl
+++ b/src/model/assets/thermalhydrogen.jl
@@ -84,6 +84,22 @@ function simple_default_data(::Type{ThermalHydrogen}, id=missing)
     )
 end
 
+function set_commodity!(::Type{ThermalHydrogen}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fuel_edge]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+end
+
 """
     make(::Type{ThermalHydrogen}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalHydrogen
 

--- a/src/model/assets/thermalhydrogen.jl
+++ b/src/model/assets/thermalhydrogen.jl
@@ -20,7 +20,7 @@ function default_data(t::Type{ThermalHydrogen}, id=missing, style="full")
 end
 
 function full_default_data(::Type{ThermalHydrogen}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Hydrogen",
@@ -58,7 +58,7 @@ function full_default_data(::Type{ThermalHydrogen}, id=missing)
 end
 
 function simple_default_data(::Type{ThermalHydrogen}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/thermalhydrogenccs.jl
+++ b/src/model/assets/thermalhydrogenccs.jl
@@ -20,7 +20,7 @@ function default_data(t::Type{ThermalHydrogenCCS}, id=missing, style="full")
 end
 
 function full_default_data(::Type{ThermalHydrogenCCS}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Hydrogen",
@@ -62,7 +62,7 @@ function full_default_data(::Type{ThermalHydrogenCCS}, id=missing)
 end
 
 function simple_default_data(::Type{ThermalHydrogenCCS}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/thermalhydrogenccs.jl
+++ b/src/model/assets/thermalhydrogenccs.jl
@@ -89,6 +89,22 @@ function simple_default_data(::Type{ThermalHydrogenCCS}, id=missing)
     )
 end
 
+function set_commodity!(::Type{ThermalHydrogenCCS}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fuel_edge]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+end
+
 """
     make(::Type{ThermalHydrogenCCS}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalHydrogenCCS
 

--- a/src/model/assets/thermalpower.jl
+++ b/src/model/assets/thermalpower.jl
@@ -79,10 +79,25 @@ function simple_default_data(::Type{ThermalPower}, id=missing)
     )
 end
 
+function set_commodity!(::Type{ThermalPower}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fuel_edge]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+end
+
 """
     make(::Type{ThermalPower}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalPower
 """
-
 function make(asset_type::Type{ThermalPower}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/thermalpower.jl
+++ b/src/model/assets/thermalpower.jl
@@ -18,7 +18,7 @@ function default_data(t::Type{ThermalPower}, id=missing, style="full")
 end
 
 function full_default_data(::Type{ThermalPower}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -53,7 +53,7 @@ function full_default_data(::Type{ThermalPower}, id=missing)
 end
 
 function simple_default_data(::Type{ThermalPower}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/thermalpower.jl
+++ b/src/model/assets/thermalpower.jl
@@ -98,6 +98,7 @@ end
 """
     make(::Type{ThermalPower}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalPower
 """
+
 function make(asset_type::Type{ThermalPower}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/thermalpowerccs.jl
+++ b/src/model/assets/thermalpowerccs.jl
@@ -85,10 +85,25 @@ function simple_default_data(::Type{ThermalPowerCCS}, id=missing)
     )
 end
 
+function set_commodity!(::Type{ThermalPowerCCS}, commodity::Type{<:Commodity}, data::AbstractDict{Symbol,Any})
+    edge_keys = [:fuel_edge]
+    if haskey(data, :fuel_commodity)
+        data[:fuel_commodity] = string(commodity)
+    end
+    if haskey(data, :edges)
+        for edge_key in edge_keys
+            if haskey(data[:edges], edge_key)
+                if haskey(data[:edges][edge_key], :commodity)
+                    data[:edges][edge_key][:commodity] = string(commodity)
+                end
+            end
+        end
+    end
+end
+
 """
     make(::Type{ThermalPowerCCS}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalPowerCCS
 """
-
 function make(asset_type::Type{ThermalPowerCCS}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/thermalpowerccs.jl
+++ b/src/model/assets/thermalpowerccs.jl
@@ -19,7 +19,7 @@ function default_data(t::Type{ThermalPowerCCS}, id=missing, style="full")
 end
 
 function full_default_data(::Type{ThermalPowerCCS}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -58,7 +58,7 @@ function full_default_data(::Type{ThermalPowerCCS}, id=missing)
 end
 
 function simple_default_data(::Type{ThermalPowerCCS}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/assets/thermalpowerccs.jl
+++ b/src/model/assets/thermalpowerccs.jl
@@ -104,6 +104,7 @@ end
 """
     make(::Type{ThermalPowerCCS}, data::AbstractDict{Symbol, Any}, system::System) -> ThermalPowerCCS
 """
+
 function make(asset_type::Type{ThermalPowerCCS}, data::AbstractDict{Symbol,Any}, system::System)
     id = AssetId(data[:id])
 

--- a/src/model/assets/vre.jl
+++ b/src/model/assets/vre.jl
@@ -13,7 +13,7 @@ function default_data(t::Type{VRE}, id=missing, style="full")
 end
 
 function full_default_data(::Type{VRE}, id=missing)
-    return Dict{Symbol, Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :transforms => @transform_data(
             :timedata => "Electricity",
@@ -33,7 +33,7 @@ function full_default_data(::Type{VRE}, id=missing)
 end
 
 function simple_default_data(::Type{VRE}, id=missing)
-    return Dict{Symbol,Any}(
+    return OrderedDict{Symbol,Any}(
         :id => id,
         :location => missing,
         :can_expand => true,

--- a/src/model/networks/location.jl
+++ b/src/model/networks/location.jl
@@ -42,7 +42,7 @@ end
 function load_locations!(system::AbstractSystem, rel_or_abs_path::String, data::AbstractDict{Symbol, Any})
     if haskey(data, :path)
         data = eager_load_json_inputs(data, rel_or_abs_path)
-        if isa(data, AbstractDict) && haskey(data, :locations)
+        if isa(data, AbstractDict) && haskey(data, :locations) && !isempty(data[:locations])
             load_locations!(system, rel_or_abs_path, data[:locations])
         end
     else

--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -135,7 +135,7 @@ function template_asset(assets_dir::AbstractString, asset_types::Vector{T}; asse
     return nothing
 end
 
-function template_asset(system::AbstractString, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
+function template_asset(system::AbstractSystem, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
     system_data = load_system_data(joinpath(system.data_dirpath, "system_data.json"); lazy_load = true)
     assets_dir = joinpath(system.data_dirpath, system_data[:assets][:path])
     for asset_type in asset_types

--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -129,8 +129,8 @@ function template_asset(system::AbstractSystem, asset_type::Type{T}; asset_name:
 end
 
 function template_asset(assets_dir::AbstractString, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
-    for asset_type in asset_types
-        template_asset(assets_dir, asset_type; style=style, format=format)
+    for (idx, asset_type) in enumerate(asset_types)
+        template_asset(assets_dir, asset_type; asset_name=asset_names[idx], style=style, format=format)
     end
     return nothing
 end
@@ -138,10 +138,7 @@ end
 function template_asset(system::AbstractSystem, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
     system_data = load_system_data(joinpath(system.data_dirpath, "system_data.json"); lazy_load = true)
     assets_dir = joinpath(system.data_dirpath, system_data[:assets][:path])
-    for asset_type in asset_types
-        template_asset(assets_dir, asset_type; style=style, format=format)
-    end
-    return nothing
+    return template_asset(assets_dir, asset_types; asset_names=asset_names, style=style, format=format)
 end
 
 function template_node(nodes_file::AbstractString, node_commodity::Type{T}; style::AbstractString="full", format::AbstractString="json", make_file::Bool=true) where T<:Commodity

--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -122,7 +122,22 @@ function template_asset(assets_dir::AbstractString, asset_type::Type{T}; asset_n
     return nothing
 end
 
+function template_asset(system::AbstractSystem, asset_type::Type{T}; asset_name::AbstractString=string(typesymbol(asset_type)), style::AbstractString="full", format::AbstractString="json") where T<:AbstractAsset
+    system_data = load_system_data(joinpath(system.data_dirpath, "system_data.json"); lazy_load = true)
+    assets_dir = joinpath(system.data_dirpath, system_data[:assets][:path])
+    return template_asset(assets_dir, asset_type; asset_name=asset_name, style=style, format=format)
+end
+
 function template_asset(assets_dir::AbstractString, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
+    for asset_type in asset_types
+        template_asset(assets_dir, asset_type; style=style, format=format)
+    end
+    return nothing
+end
+
+function template_asset(system::AbstractString, asset_types::Vector{T}; asset_names::Vector{String}=string.(asset_types), style::AbstractString="full", format::AbstractString="json") where T <: Union{Type, UnionAll}
+    system_data = load_system_data(joinpath(system.data_dirpath, "system_data.json"); lazy_load = true)
+    assets_dir = joinpath(system.data_dirpath, system_data[:assets][:path])
     for asset_type in asset_types
         template_asset(assets_dir, asset_type; style=style, format=format)
     end

--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -153,17 +153,17 @@ function template_asset(assets_dir::AbstractString, asset_type::Type{T}; asset_n
         asset_commodity = asset_type_info.parameter
         set_commodity!(asset_type, asset_commodity, asset_data[:instance_data][1])
     end
-    if format == "json"
+    if lowercase(format) == "json"
         filepath = find_available_filepath(joinpath(assets_dir, "$asset_name.json"))
         write_json(filepath, Dict{Symbol,Any}(Symbol(asset_name) => asset_data))
-    elseif format == "csv"
+    elseif lowercase(format) == "csv"
         filepath = find_available_filepath(joinpath(assets_dir, "$asset_name.csv"))
         csv_data = json_to_csv(Dict{Symbol,Any}(Symbol(asset_name) => asset_data))
         for (_, data) in csv_data.asset_data
             write_csv(filepath, DataFrame(data))
         end
     else
-        error("Unsupported format: $format. Supported formats are $(input_formats())")
+        error("Unsupported format: $format. Supported formats are $(@input_formats())")
     end
     return nothing
 end

--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -283,7 +283,7 @@ function template_subcommodity(comm_file::AbstractString, subcommodities::Vector
     for (idx, subcommodity) in enumerate(subcommodities)
         commodity = commodities[idx]
         if commodity ∉ listed_commodities
-            @warn("Parent commodity $commodity does not exist. Skipping creating $subcommodity")
+            @warn("Super-commodity $commodity does not exist. Skipping creating $subcommodity")
             continue
         elseif subcommodity in listed_commodities
             @warn("Subcommodity $subcommodity already exists. Skipping creating $subcommodity")
@@ -297,7 +297,7 @@ function template_subcommodity(comm_file::AbstractString, subcommodities::Vector
         )
         push!(new_subcommodities, new_subcommodity)
     end
-    commodities_file[:commodities] = Set{Any}(commodities_file[:commodities])
+    commodities_file[:commodities] = OrderedSet{Any}(commodities_file[:commodities])
     for subc in new_subcommodities
         push!(commodities_file[:commodities], subc)
     end


### PR DESCRIPTION
This PR implements one bug fix and one new feature:

- It updates the default_system_data to have "system/locations.json" as the default path to the Locations file, instead of "system/locations".
- It allows the template functions to target a System object instead of the relevant files.

e.g. The following now work:

```julia
system = template_system("ExampleSystems/template_example")
template_node(system, MacroEnergy.Hydrogen)
template_node(system, [MacroEnergy.Electricity, MacroEnergy.CO2])
template_location(system, ["Boston", "New York", "Princeton"])
template_asset(system, [MacroEnergy.ThermalPower, MacroEnergy.GasStorage, MacroEnergy.VRE], style="full", format="json")
```

The previous version also still works:
```julia
template_system("ExampleSystems/template_example")
template_node("ExampleSystems/template_example/system/nodes.json", MacroEnergy.Hydrogen)
template_node("ExampleSystems/template_example/system/nodes.json", [MacroEnergy.Electricity, MacroEnergy.CO2])
template_location("ExampleSystems/template_example/system/locations.json", ["Boston", "New York", "Princeton"])
template_asset("ExampleSystems/template_example/system/assets", [MacroEnergy.ThermalPower, MacroEnergy.GasStorage, MacroEnergy.VRE], style="full", format="json")
```
