### PR TITLE
Retrofit feature

### DIFF
--- a/ExampleSystems/cement_retrofit/assets/traditional_cement.json
+++ b/ExampleSystems/cement_retrofit/assets/traditional_cement.json
@@ -58,6 +58,38 @@
                     },
                     "retrofit_options": [
                         {
+                            "template_id": "traditional_cement_MA",
+                            "id": "traditional_cement_MA_retrofitfom",
+                            "edges": {
+                                "cement_edge": {
+                                    "is_retrofit": true,
+                                    "retrofit_efficiency": 0.9,
+                                    "investment_cost": 5000,
+                                    "fixed_om_cost": 10
+                                }
+                            }
+                        },
+                        {
+                            "template_id": "traditional_cement_MA",
+                            "id": "traditional_cement_MA_retrofitfuel",
+                            "fuel_commodity": "LiquidFuels",
+                            "transforms": {
+                                "fuel_consumption_rate": 1.06,
+                                "fuel_emission_rate": 0.05
+                            },
+                            "edges": {
+                                "fuel_edge": {
+                                    "type": "LiquidFuels",
+                                    "start_vertex": "liqfuel_source"
+                                },
+                                "cement_edge": {
+                                    "is_retrofit": true,
+                                    "retrofit_efficiency": 1.0,
+                                    "investment_cost": 220939
+                                }
+                            }
+                        },
+                        {
                             "template_id": "oxyfuel_cement_MA",
                             "id": "oxyfuel_cement_MA_retrofit",
                             "edges": {


### PR DESCRIPTION
### Description
This feature allows the capacity of one asset to be retrofitted into another, for assets with capacity decisions defined on their edges (currently, retrofitting of storage capacity hasn’t been implemented). The example system I've tested it on is `cement_retrofit`.

The screenshot below shows the inputs for a traditional cement plant that has 3 retrofit options. For each retrofit option, `template_id` specifies the asset from which the retrofitting asset’s attributes should be copied from. `id` is the id for this new retrofit option, and the remaining fields specify how the retrofitting asset’s attributes should be changed from the “template” asset.

In this example, the first retrofitting option is a traditional cement plant with cheaper O+M costs, the second retrofitting option is a traditional plant with a different fuel option, and the third retrofit option is an oxyfuel cement plant.

`can_retrofit` needs to be set to `true` for edges that can be retrofitted, and `is_retrofit` needs to be set to `true` for edges that are the retrofitting option. `retrofit efficiency` is the fraction of capacity on the `can_retrofit` edge that can be transformed into capacity for the `is_retrofit` edge. `investment_cost` is the cost of retrofitting one asset into another.

Also, `"Retrofitting": true` needs to be in the `macro_settings.json` file. This is mainly to check and make sure cases with multiple periods can't be run with retrofitting, since this feature hasn't been integrated with multi-stage modeling.

<img width="408" height="761" alt="image" src="https://github.com/user-attachments/assets/5b11ffd6-0cd6-4cbd-a3f8-32242c30d79f" />


This second screenshot shows the inputs for the template oxyfuel cement plant. If the user wants to prevent greenfield build of this asset, they can set `can_expand` to 0.

<img width="219" height="144" alt="image" src="https://github.com/user-attachments/assets/c1d64987-a9a0-405b-bc22-a0fc03a8ef98" />

### Limitations
- With this implementation, a `can_retrofit` edge can be retrofitted by multiple `is_retrofit` edges, but the opposite is not true (I think the latter case would be very rare).
- The model currently only decides between the separate retrofit options - it does not consider the possibility of combined retrofits.
- **The feature doesn't work yet for multi-stage modeling**. I was working on integrating it with the multi-stage feature, but I ran into bugs related to adding the retrofitting constraints, which I haven't resolved yet (test cases are in `multistage_with_cement` and `multistage_with_cement_retrofit`.

### Other notes:
- `.json` files for assets are templates for retrofit options, need to be denoted with "_retrofit_option” at the end of their filename, so that they can be loaded into Macro first. This is so their data can be copied when making a new asset that is a retrofit option.
- I’ve added an `input_data` attribute to the `System` datatype. This is to be able to access input data from other assets when making new retrofit option assets, since they might need to copy data from a different asset file.

I’m looking for some feedback on the current implementation of this feature for single period modeling before I continue to integrate it with the multi-stage modeling feature.
