### PR TITLE
Print settings as part of results

### DIFF
--- a/src/utilities/model_templates.jl
+++ b/src/utilities/model_templates.jl
@@ -78,8 +78,8 @@ function template_run_file(filepath::AbstractString)
             using MacroEnergy
             # using Gurobi
 
-            (system, model) = run_case(@__DIR__);
-            # (system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer);
+            (case, model) = run_case(@__DIR__);
+            # (case, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer);
             """
         )
     end

--- a/src/utilities/run_tools.jl
+++ b/src/utilities/run_tools.jl
@@ -55,5 +55,5 @@ function run_case(
         end
     end
 
-    return case.systems, solution
+    return case, solution
 end

--- a/src/write_outputs/write_output_utilities.jl
+++ b/src/write_outputs/write_output_utilities.jl
@@ -915,7 +915,7 @@ function write_outputs(case_path::AbstractString, case::Case, model::Model)
         mkpath(results_dir)
         write_outputs(results_dir, period, model)
     end
-
+    write_settings(case, joinpath(case_path, "settings.json"))
     return nothing
 end
 
@@ -1284,4 +1284,12 @@ function evaluate_vtheta_in_expression(m::Model, expr::Symbol, subop_sol::Dict, 
     # Evaluate the expression `expr` using the mapping
     return value(x -> theta_to_cost[x], m[expr])
     
+end
+
+function write_settings(case::Case, filepath::AbstractString)
+    settings = Dict{Symbol, Any}(
+        :case_settings => case.settings,
+        :system_settings => [system.settings for system in case.systems]
+    )
+    write_json(filepath, settings)
 end

--- a/src/write_outputs/write_output_utilities.jl
+++ b/src/write_outputs/write_output_utilities.jl
@@ -942,7 +942,7 @@ function write_outputs(case_path::AbstractString, case::Case, myopic_results::My
         mkpath(results_dir)
         write_outputs(results_dir, period, myopic_results.models[period_idx])
     end
-
+    write_settings(case, joinpath(case_path, "settings.json"))
     return nothing
 end
 
@@ -987,7 +987,7 @@ function write_outputs(case_path::AbstractString, case::Case, bd_results::Bender
         write_costs(joinpath(results_dir, "costs.csv"), period, costs)
         write_undiscounted_costs(joinpath(results_dir, "undiscounted_costs.csv"), period, costs)
     end
-
+    write_settings(case, joinpath(case_path, "settings.json"))
     return nothing
 end
 

--- a/test/test_inputs/run.jl
+++ b/test/test_inputs/run.jl
@@ -1,8 +1,6 @@
 using MacroEnergy
 using Gurobi
 
-#(system, model) = run_case(@__DIR__; optimizer=Gurobi.Optimizer);
-
 println()
 
 system = MacroEnergy.load_system(@__DIR__)


### PR DESCRIPTION
## Description

This PR addresses the points raised in #119 . The case and period / system settings will now be printed in the top-level of the results folder.

We will need to update how we handle settings config in the future. I'm merging this so everyone has it in the meantime.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Addresses #119 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.