### PR TITLE
Fix bug with subcommodities

### DIFF
--- a/src/load_inputs/load.jl
+++ b/src/load_inputs/load.jl
@@ -95,9 +95,12 @@ end
 
 function check_and_convert_type(data::AbstractDict{Symbol,Any}, m::Module = MacroEnergy)
     if !haskey(data, :type)
-        throw(ArgumentError("Instance data does not have a :type field"))
+        throw(ArgumentError("Instance data requires a :type field"))
     end
     type = Symbol(data[:type])
+    if haskey(commodity_types(m), type)
+        return commodity_types(m)[type]
+    end
     validate_type_attribute(type, m)
     return getfield(m, type)
 end

--- a/src/load_inputs/load_commodities.jl
+++ b/src/load_inputs/load_commodities.jl
@@ -14,6 +14,10 @@ end
 
 ###### ###### ###### ######
 
+function clean_line(line::AbstractString)::String
+    return join(split(strip(line)), " ")
+end
+
 function make_commodity(new_commodity::Union{String,Symbol}, m::Module = MacroEnergy)::String
     s = "abstract type $new_commodity <: $m.Commodity end"
     eval(Meta.parse(s))
@@ -67,7 +71,6 @@ function load_commodities(data::AbstractVector{<:AbstractString}, rel_path::Abst
 end
 
 function load_commodities(commodities::AbstractVector{<:Any}, rel_path::AbstractString=""; write_subcommodities::Bool=false)
-    # subcommodities_path = load_subcommodities_from_file()
     register_commodity_types!()
 
     macro_commodities = commodity_types()
@@ -96,7 +99,7 @@ function load_commodities(commodities::AbstractVector{<:Any}, rel_path::Abstract
         end
     end
 
-    subcommodities_lines = String[]
+    subcommodities_lines = Set{String}()
 
     for commodity in all_sub_commodities
         @debug("Iterating over user-defined subcommodities")
@@ -121,7 +124,6 @@ function load_commodities(commodities::AbstractVector{<:Any}, rel_path::Abstract
     @debug(" -- Done adding subcommodities")
 
     if write_subcommodities && !isempty(subcommodities_lines)
-        @debug("Writing subcommodities to file $(user_subcommodities_path(subcommodities_path))")
         write_user_subcommodities(rel_path, subcommodities_lines)
         @debug(" -- Done writing subcommodities")
     end

--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -89,7 +89,8 @@ Base.@kwdef mutable struct Edge{T} <: AbstractEdge{T}
 end
 
 function target_is_valid(commodity::Type{<:Commodity}, target::T) where T<:Union{Node, AbstractStorage}
-    if commodity <: commodity_type(target)
+    target_commodity = commodity_type(target)
+    if (commodity === target_commodity) || (commodity <: target_commodity)
         return true
     end
     return false

--- a/src/utilities/user_additions.jl
+++ b/src/utilities/user_additions.jl
@@ -54,9 +54,20 @@ function create_user_additions_module(case_path::AbstractString=pwd())
     close(io)
 end
 
-function write_user_subcommodities(case_path::AbstractString, subcommodities_lines::Vector{String})
+function write_user_subcommodities(case_path::AbstractString, subcommodities_lines::Set{String})
     user_subcommodities_path = user_additions_subcommodities_path(case_path)
+    @debug(" -- Writing subcommodities to file $(user_subcommodities_path)")
     mkpath(dirname(user_subcommodities_path))
+    # Read each lines from the file into a Set{String} to avoid duplicates
+    existing_lines = Set{String}()
+    if isfile(user_subcommodities_path)
+        for line in eachline(user_subcommodities_path) 
+            if !isempty(strip(line))
+                push!(existing_lines, line)
+            end
+        end
+    end
+    union!(subcommodities_lines, existing_lines)
     io = open(user_subcommodities_path, "w")
     for line in subcommodities_lines
         println(io, line)


### PR DESCRIPTION
## Description

This PR adjusts how Nodes are created to use UserAdditions.subcommodity instead of forcing the sub-commodity to become MacroEnergy.subcommodity through the use of get `getfield(MacroEnergy, subcommodity)` function. This resolves a bug some people were getting when repeatedly running cases.

I didn't switch to explicitly exporting the types from UserAdditions, but we may need to do that in the future.

I have also changed the creation of the user subcommodities file to merge the existing and new subcommodities, instead of only keeping the new ones.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.