### PR TITLE
add real world parameters as default set to aluminum sector

### DIFF
--- a/src/model/assets/aluminaplant.jl
+++ b/src/model/assets/aluminaplant.jl
@@ -24,10 +24,10 @@ function full_default_data(::Type{AluminaPlant}, id=missing)
         :id => id,
         :transforms => @transform_data(
             :timedata => "Alumina",
-            :elec_alumina_rate => 1.0,
-            :bauxite_alumina_rate => 1.0,
-            :fuel_alumina_rate => 1.0,
-            :fuel_emissions_rate => 1.0,
+            :elec_alumina_rate => 0.15,
+            :bauxite_alumina_rate => 2.4,
+            :fuel_alumina_rate => 2.917,
+            :fuel_emissions_rate => 0.181048235160161,
             :constraints => Dict{Symbol, Bool}(
                 :BalanceConstraint => true,
             ),
@@ -41,7 +41,13 @@ function full_default_data(::Type{AluminaPlant}, id=missing)
                 :has_capacity => true,
                 :can_retire => true,
                 :can_expand => true,
-                :can_retire => true,
+                :capacity_size => 1,
+                :investment_cost => 3600000,
+                :wacc => 0.039,
+                :lifetime => 20,
+                :capital_recovery_period => 20,
+                :fixed_om_cost => 613200,
+                :variable_om_cost => 30,
                 :constraints => Dict{Symbol, Bool}(
                     :CapacityConstraint => true,
                 )
@@ -69,15 +75,18 @@ function simple_default_data(::Type{AluminaPlant}, id=missing)
         :existing_capacity => 0.0,
         :capacity_size => 1.0,
         :timedata => "Alumina",
-        :elec_alumina_rate => 1.0,
-        :bauxite_alumina_rate => 1.0,
-        :fuel_alumina_rate => 1.0,
-        :fuel_emissions_rate => 1.0,
+        :elec_alumina_rate => 0.15,
+        :bauxite_alumina_rate => 2.4,
+        :fuel_alumina_rate => 2.917,
+        :fuel_emissions_rate => 0.181048235160161,
         :co2_sink => missing,
         :uc => false,
-        :investment_cost => 0.0,
-        :fixed_om_cost => 0.0,
-        :variable_om_cost => 0.0,
+        :investment_cost => 3600000,
+        :wacc => 0.039,
+        :lifetime => 20,
+        :capital_recovery_period => 20,
+        :fixed_om_cost => 613200,
+        :variable_om_cost => 30,
     )
 end
 
@@ -251,22 +260,22 @@ function make(asset_type::Type{AluminaPlant}, data::AbstractDict{Symbol,Any}, sy
             elec_edge.id => 1.0,
             fuel_edge.id => 0.0,
             bauxite_edge.id => 0.0,
-            alumina_edge.id => get(transform_data, :elec_alumina_rate, 1.0)
+            alumina_edge.id => get(transform_data, :elec_alumina_rate, 0.15)
         ),
         :bauxite_to_alumina => Dict(
             elec_edge.id => 0.0,
             fuel_edge.id => 0.0,
             bauxite_edge.id => 1.0,
-            alumina_edge.id => get(transform_data, :bauxite_alumina_rate, 1.0)
+            alumina_edge.id => get(transform_data, :bauxite_alumina_rate, 2.4)
         ),
         :fuel_to_alumina => Dict(
             elec_edge.id => 0.0,
             fuel_edge.id => 1.0,
             bauxite_edge.id => 0.0,
-            alumina_edge.id => get(transform_data, :fuel_alumina_rate, 1.0)
+            alumina_edge.id => get(transform_data, :fuel_alumina_rate, 2.917)
         ),
         :emissions => Dict(
-            fuel_edge.id => get(transform_data, :fuel_emissions_rate, 1.0),
+            fuel_edge.id => get(transform_data, :fuel_emissions_rate, 0.181048235160161),
             co2_edge.id => 1.0
         )
     )

--- a/src/model/assets/aluminumrefining.jl
+++ b/src/model/assets/aluminumrefining.jl
@@ -25,7 +25,7 @@ function full_default_data(::Type{AluminumRefining}, id=missing)
         :id => id,
         :transforms => @transform_data(
             :timedata => "Aluminum",              # Time series data identifier
-            :elec_aluminum_rate => 1.0,           # Rate of electricity needed per unit of aluminum
+            :elec_aluminum_rate => 2.0,           # Rate of electricity needed per unit of aluminum
             :aluminumscrap_aluminum_rate => 1.05, # Rate of aluminum scrap needed per unit of aluminum (includes 5% loss)
             :aluminum_emissions_rate => 0.0,      # Emissions rate for aluminum production
             :constraints => Dict{Symbol, Bool}(
@@ -41,8 +41,15 @@ function full_default_data(::Type{AluminumRefining}, id=missing)
             :aluminum_edge => @edge_data(
                 :commodity=>"Aluminum",
                 :has_capacity => true,            # Edge has capacity constraints
-                :can_retire => true,              # Capacity can be retired
+                :can_retire => true,             # Capacity can be retired
                 :can_expand => true,              # Capacity can be expanded
+                :capacity_size => 1,
+                :investment_cost => 2400000,
+                :wacc => 0.039,
+                :lifetime => 20,
+                :capital_recovery_period => 20,
+                :fixed_om_cost => 420000,
+                :variable_om_cost => 123,
                 :constraints => Dict{Symbol, Bool}(
                     :CapacityConstraint => true,  # Enforces capacity constraints
                 )
@@ -62,16 +69,19 @@ function simple_default_data(::Type{AluminumRefining}, id=missing)
         :id => id,
         :location => missing,
         :can_expand => true,                      # Asset can be expanded
-        :can_retire => true,                      # Asset can be retired
+        :can_retire => true,                     # Asset can be retired
         :existing_capacity => 0.0,                # Initial capacity
         :capacity_size => 1.0,                    # Size of capacity units
         :timedata => "Aluminum",                  # Time series data identifier
-        :elec_aluminum_rate => 1.0,               # Rate of electricity needed per unit of aluminum
+        :elec_aluminum_rate => 2.0,               # Rate of electricity needed per unit of aluminum
         :aluminumscrap_aluminum_rate => 1.05,     # Rate of aluminum scrap needed per unit of aluminum
         :aluminum_emissions_rate => 0.0,          # Emissions rate for aluminum production
-        :investment_cost => 0.0,                  # Cost to build new capacity
-        :fixed_om_cost => 0.0,                    # Fixed operating and maintenance cost
-        :variable_om_cost => 0.0,                 # Variable operating and maintenance cost
+        :investment_cost => 2400000,              # Cost to build new capacity
+        :wacc => 0.039,
+        :lifetime => 20,
+        :capital_recovery_period => 20,
+        :fixed_om_cost => 420000,                 # Fixed operating and maintenance cost
+        :variable_om_cost => 123,                 # Variable operating and maintenance cost
     )
 end
 
@@ -195,12 +205,12 @@ function make(asset_type::Type{AluminumRefining}, data::AbstractDict{Symbol,Any}
         :elec_to_aluminum => Dict(
             elec_edge.id => 1.0,                  # Electricity input coefficient
             aluminumscrap_edge.id => 0.0,         # No direct conversion from electricity to aluminum scrap
-            aluminum_edge.id => get(transform_data, :elec_aluminum_rate, 1.0)  # Electricity needed per unit of aluminum
+            aluminum_edge.id => get(transform_data, :elec_aluminum_rate, 2.0)  # Electricity needed per unit of aluminum
         ),
         :aluminumscrap_to_aluminum => Dict(
             elec_edge.id => 0.0,                  # No direct conversion from aluminum scrap to electricity
             aluminumscrap_edge.id => 1.0,         # Aluminum scrap input coefficient
-            aluminum_edge.id => get(transform_data, :aluminumscrap_aluminum_rate, 1.0)  # Aluminum scrap needed per unit of aluminum
+            aluminum_edge.id => get(transform_data, :aluminumscrap_aluminum_rate, 1.05)  # Aluminum scrap needed per unit of aluminum
         )
     )
     return AluminumRefining(id, aluminumrefining_transform, elec_edge, aluminumscrap_edge, aluminum_edge)

--- a/src/model/assets/aluminumsmelting.jl
+++ b/src/model/assets/aluminumsmelting.jl
@@ -21,10 +21,10 @@ function full_default_data(::Type{AluminumSmelting}, id=missing)
         :id => id,
         :transforms => @transform_data(
             :timedata => "Aluminum",
-            :elec_aluminum_rate => 1.0,
-            :alumina_aluminum_rate => 1.0,
-            :graphite_aluminum_rate => 1.0,
-            :graphite_emissions_rate => 1.0,
+            :elec_aluminum_rate => 13.3,
+            :alumina_aluminum_rate => 1.93,
+            :graphite_aluminum_rate => 0.45,
+            :graphite_emissions_rate => 3.67,
             :constraints => Dict{Symbol, Bool}(
                 :BalanceConstraint => true,
             ),
@@ -38,7 +38,15 @@ function full_default_data(::Type{AluminumSmelting}, id=missing)
                 :has_capacity => true,
                 :can_retire => true,
                 :can_expand => true,
-                :can_retire => true,
+                :capacity_size => 1,
+                :investment_cost => 12000000,
+                :wacc => 0.039,
+                :lifetime => 20,
+                :capital_recovery_period => 20,
+                :fixed_om_cost => 2040000,
+                :variable_om_cost => 62,
+                :startup_cost => 1469798,
+                :uc => false,
                 :constraints => Dict{Symbol, Bool}(
                     :CapacityConstraint => true,
                 )
@@ -66,16 +74,19 @@ function simple_default_data(::Type{AluminumSmelting}, id=missing)
         :existing_capacity => 0.0,
         :capacity_size => 1.0,
         :timedata => "Aluminum",
-        :elec_aluminum_rate => 1.0,
-        :alumina_aluminum_rate => 1.0,
-        :graphite_aluminum_rate => 1.0,
-        :graphite_emissions_rate => 1.0,
+        :elec_aluminum_rate => 13.3,
+        :alumina_aluminum_rate => 1.93,
+        :graphite_aluminum_rate => 0.45,
+        :graphite_emissions_rate => 3.67,
         :co2_sink => missing,
         :uc => false,
-        :investment_cost => 0.0,
-        :fixed_om_cost => 0.0,
-        :variable_om_cost => 0.0,
-        :startup_cost => 0.0,
+        :investment_cost => 12000000,
+        :wacc => 0.039,
+        :lifetime => 20,
+        :capital_recovery_period => 20,
+        :fixed_om_cost => 2040000,
+        :variable_om_cost => 62,
+        :startup_cost => 1469798,
         :min_up_time => 0,
         :min_down_time => 0,
         :ramp_up_fraction => 0.0,
@@ -277,22 +288,22 @@ function make(asset_type::Type{AluminumSmelting}, data::AbstractDict{Symbol,Any}
             elec_edge.id => 1.0,
             alumina_edge.id => 0.0,
             graphite_edge.id => 0.0,
-            aluminum_edge.id => get(transform_data, :elec_aluminum_rate, 1.0)
+            aluminum_edge.id => get(transform_data, :elec_aluminum_rate, 13.3)
         ),
         :alumina_to_aluminum => Dict(
             elec_edge.id => 0.0,
             alumina_edge.id => 1.0,
             graphite_edge.id => 0.0,
-            aluminum_edge.id => get(transform_data, :alumina_aluminum_rate, 1.0)
+            aluminum_edge.id => get(transform_data, :alumina_aluminum_rate, 1.93)
         ),
         :graphite_to_aluminum => Dict(
             elec_edge.id => 0.0,
             alumina_edge.id => 0.0,
             graphite_edge.id => 1.0,
-            aluminum_edge.id => get(transform_data, :graphite_aluminum_rate, 1.0)
+            aluminum_edge.id => get(transform_data, :graphite_aluminum_rate, 0.45)
         ),
         :emissions => Dict(
-            graphite_edge.id => get(transform_data, :graphite_emissions_rate, 1.0),
+            graphite_edge.id => get(transform_data, :graphite_emissions_rate, 3.67),
             co2_edge.id => 1.0
         )
     )


### PR DESCRIPTION
## Description
Use real-world numbers to update the default parameters (typical cost and stoichiometry data in China) of the aluminum assets

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement (please add a section below for benchmark results or performance metrics)
- [✓] Other (update the default parameters for aluminum sector assets)


## Checklist:
- [ ✓] I have performed a self-review of my own code
- [ ✓] I have commented my code, particularly in hard-to-understand areas
- [ ✓] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [ ✓] My changes generate no new warnings
- [ ✓] I have tested the code to ensure it works as expected
- [ ✓] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [✓] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.
