### PR TITLE
bug fixes for json_to_csv and load function

### DIFF
--- a/src/load_inputs/load.jl
+++ b/src/load_inputs/load.jl
@@ -8,7 +8,9 @@ function load!(system::System, file_path::AbstractString)::Nothing
     if isfile(file_path)
         load!(system, load_inputs(file_path))
     elseif isdir(file_path)
-        files = get_json_files(file_path)
+        json_files = get_json_files(file_path)
+        csv_files = get_csv_files(file_path)
+        files = vcat(json_files, csv_files)
         files = sort(files, by = x -> occursin("_retrofit_option", x) ? 0 : 1) # Sorts files so that retrofit options are loaded first
         for file in files
             load!(system, joinpath(file_path, file))

--- a/src/load_inputs/load_csv_inputs.jl
+++ b/src/load_inputs/load_csv_inputs.jl
@@ -309,7 +309,7 @@ function file_suffix(file_path::AbstractString, suffix_options)
     return ""
 end
 
-function convert_json_to_csv(file_path::AbstractString, rel_path::AbstractString=dirname(file_path), lazy_load::Bool=false, compress::Bool=false)
+function convert_json_to_csv(file_path::AbstractString, rel_path::AbstractString=dirname(file_path), lazy_load::Bool=true, compress::Bool=false)
     json_data = load_json_inputs(file_path; rel_path=rel_path, lazy_load=lazy_load)
     csv_data = json_to_csv(json_data)
     fillmissing!(csv_data)


### PR DESCRIPTION
**Summary**

This PR fixes two issues related to CSV input handling in MacroEnergy.

1. `load!` doesn't load CSV asset files

The current load!(system, file_path) only picks up JSON files and ignores .csv files in asset directories. This update adds CSV detection so both JSON and CSV asset files are loaded correctly.

2. `convert_json_to_csv` mis-handles availability when `lazy_load = false`

When lazy_load is false, the "availability" field isn’t parsed as a dictionary of timeseries references (see example json input with the "availability" field). Instead, it gets flattened, which causes duplicated column headers in vector_data.csv. Setting `lazy_load = true` ensures "availability" is treated as a dictionary and each key maps to a unique CSV column.

<img width="713" height="646" alt="image" src="https://github.com/user-attachments/assets/44cf5ae8-b942-484a-ace1-d26852215c76" />
