### PR TITLE
Fix issue with cross references in documentation

### DIFF
--- a/docs/src/Manual/Storage.md
+++ b/docs/src/Manual/Storage.md
@@ -1,4 +1,4 @@
-# Storage components
+# Storage
 
 ## Contents
 

--- a/docs/src/References/3_macro_objects.md
+++ b/docs/src/References/3_macro_objects.md
@@ -4,32 +4,32 @@
 Pages = ["2_macro_objects.md"]
 ```
 
-## `Edge` (with and without UC)
+## [`Edge`](@id edge-reference)
 ```@docs
 MacroEnergy.Edge
 ```
 
-## `EdgeWithUC`
+## [`EdgeWithUC`](@id edgewithuc-reference)
 ```@docs
 MacroEnergy.EdgeWithUC
 ```
 
-## `Node`
+## [`Node`](@id node-reference)
 ```@docs
 MacroEnergy.Node
 ```
 
-## `Storage`
+## [`Storage`](@id storage-reference)
 ```@docs
 MacroEnergy.Storage
 ```
 
-## `Transformation`
+## [`Transformation`](@id transformation-reference)
 ```@docs
 MacroEnergy.Transformation
 ```
 
-## `@AbstractVertexBaseAttributes`
+## [`@AbstractVertexBaseAttributes`](@id abstractvertexbaseattributes-reference)
 ```@docs
 MacroEnergy.@AbstractVertexBaseAttributes
 ```


### PR DESCRIPTION
## Description

After merging PR #142, the documentation did not build on main. This is due to cross reference errors caused by `docs/src/Manual/Storage.md` whose header generates the same slug as 
```
## `Storage`
```@docs
MacroEnergy.Storage```
```
in `docs/src/References/3_macro_objects.md`.

This issue was not picked by automatic tests run in PR #142 because they used Documenter v.1.15.0, where it was only reported as warning but not an error. Main has since updated to Documenter v.1.16.0 which is now throwing an error for duplicated slugs.

The fix is to change header in `docs/src/Manual/Storage.md` so that it does not generate the same slug as the reference in `docs/src/References/3_macro_objects.md`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.