### PR TITLE
Fix issue with gas storage default constraints

### DIFF
--- a/src/model/assets/gasstorage.jl
+++ b/src/model/assets/gasstorage.jl
@@ -36,6 +36,7 @@ function full_default_data(::Type{GasStorage}, id=missing)
         :storage => @storage_data(
             :commodity => missing,
             :constraints => Dict{Symbol, Bool}(
+                :BalanceConstraint => true,
                 :StorageCapacityConstraint => true,
             ),
         ),


### PR DESCRIPTION
## Description
Gas storage assets were not including storage balance constraints by default, causing mistakes if a user did not explicitly request the balance to be satisfied.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x ] My changes generate no new warnings
- [ x] I have tested the code to ensure it works as expected
- [ x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [ x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.
