### PR TITLE
Fix writing of duals with MILP

### DIFF
--- a/src/model/solver.jl
+++ b/src/model/solver.jl
@@ -85,13 +85,8 @@ function ensure_duals_available!(model::Model)
     # Fix integer and binary variables to their current values
     fix_discrete_variables(model);
     
-    # Re-solve the LP model silently
-    was_silent = get_attribute(model, MOI.Silent())
-    set_silent(model)
+    # Re-solve the LP model
     optimize!(model)
-    
-    # Restore original silent setting if it was not already set
-    was_silent || unset_silent(model)
     
     # Verify that duals are now available
     assert_is_solved_and_feasible(model)


### PR DESCRIPTION
## Description
This PR fixes the writing of the duals when using integer decision variables. 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.