### PR TITLE
Fix warning when deleting Julia workers in Benders

### DIFF
--- a/src/utilities/run_tools.jl
+++ b/src/utilities/run_tools.jl
@@ -158,8 +158,8 @@ function run_case(
 
         # If Benders, delete processes
         if isa(solution_algorithm(case), Benders)
-            if case.settings.BendersSettings[:Distributed] && length(workers()) > 1
-                rmprocs.(workers())
+            if case.settings.BendersSettings[:Distributed] && nprocs() > 1
+                rmprocs(workers())
             end
         end
 
@@ -172,5 +172,6 @@ function run_case(
 end
 
 function case_cleanup()
-    rmprocs(workers())  # Ensure all processes are removed
+    # Only remove distributed processes (workers beyond the main process)
+    nprocs() > 1 && rmprocs(workers())
 end


### PR DESCRIPTION
## Description
This PR aims to remove the `Warning: rmprocs: process 1 not removed` from Distributed.jl. The code checks for distributed workers beyond the main process and removes them if found.

## Type of change
Please delete options that are not relevant.

- [x] Chore: warning suppression

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
By running an example system. 

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.