### PR TITLE
Handle JuMP warning about improper expression index

### DIFF
--- a/src/model/myopic.jl
+++ b/src/model/myopic.jl
@@ -82,11 +82,11 @@ function run_myopic_iteration!(case::Case, opt::Optimizer)
         variable_cost[period_idx] = model[:eVariableCost];
         unregister(model,:eVariableCost)
     
-        @expression(model, eFixedCostByPeriod[period_idx in [period_idx]], discount_factor[period_idx] * fixed_cost[period_idx])
-        @expression(model, eInvestmentFixedCostByPeriod[period_idx in [period_idx]], discount_factor[period_idx] * investment_cost[period_idx])
-        @expression(model, eOMFixedCostByPeriod[period_idx in [period_idx]], discount_factor[period_idx] * om_fixed_cost[period_idx])
+        @expression(model, eFixedCostByPeriod[idx in [period_idx]], discount_factor[idx] * fixed_cost[idx])
+        @expression(model, eInvestmentFixedCostByPeriod[idx in [period_idx]], discount_factor[idx] * investment_cost[idx])
+        @expression(model, eOMFixedCostByPeriod[idx in [period_idx]], discount_factor[idx] * om_fixed_cost[idx])
         @expression(model, eFixedCost, eFixedCostByPeriod[period_idx])
-        @expression(model, eVariableCostByPeriod[period_idx in [period_idx]], discount_factor[period_idx] * opexmult[period_idx] * variable_cost[period_idx])
+        @expression(model, eVariableCostByPeriod[idx in [period_idx]], discount_factor[idx] * opexmult[idx] * variable_cost[idx])
         @expression(model, eVariableCost, eVariableCostByPeriod[period_idx])
         @objective(model, Min, model[:eFixedCost] + model[:eVariableCost])
 


### PR DESCRIPTION
## Description

This PR updates how we set the indices of the "byPeriod" expressions (e.g. eFixedCostByPeriod) so that we avoid this error:

<img width="1046" height="130" alt="Screenshot 2026-02-07 at 7 14 35 AM" src="https://github.com/user-attachments/assets/7a0fc45d-459d-4b20-be05-7edb06348ff3" />

This doesn't change the myopic or non-myopic results in my testing

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.