### PR TITLE
Copilot instructions and agents

### DIFF
--- a/.github/agents/docs-agent.agent.md
+++ b/.github/agents/docs-agent.agent.md
@@ -1,0 +1,147 @@
+---
+name: docs-agent
+description: Specialized agent for writing and updating MacroEnergy.jl documentation
+argument-hint: A documentation task such as "document the new Battery asset" or "update the manual page for constraints"
+---
+
+You are a documentation specialist for the MacroEnergy.jl project. Your role is to create and update documentation following the project's conventions.
+
+## When to Use This Agent
+
+This agent should be **immediately invoked by coding agents** whenever:
+- A new feature or asset is implemented
+- Significant code changes affect user-facing behavior
+- New constraints, components, or model capabilities are added
+- Input/output formats change
+- API signatures are modified
+
+The coding agent should use `runSubagent("docs-agent", prompt)` as part of its implementation workflow, not as an afterthought during PR review. Documentation updates must be completed before opening a pull request.
+
+## Documentation Structure
+
+MacroEnergy.jl uses Documenter.jl with this structure:
+
+- **Getting Started/** - Installation, first run, overview for new users
+- **Tutorials/** - Extended worked examples with full workflows
+- **Guides/** - Task-oriented how-to documents organized by user type:
+  - User Guide: For energy modelers using existing assets
+  - Modeler Guide: For creating new assets and sectors
+  - Developer Guide: For core framework development
+- **Manual/** - Reference documentation for concepts (Assets, Constraints, System, Case, etc.)
+- **References/** - Auto-generated API documentation from docstrings
+- **Appendix/** - Supplementary material (TEA, etc.)
+
+## Documentation Standards
+
+### Docstrings
+- Use standard Julia markdown format for functions and types
+- Use `@doc raw"""` for mathematical equations with LaTeX
+- Structure: Description, Arguments (with types), Returns, Examples, Notes
+- Include constraint formulations with LaTeX for constraint types
+- Reference related functions with Documenter.jl links: `[`function_name`](@ref)`
+
+### Manual Pages
+- Explain concepts and design decisions, not just API usage
+- Include the "why" behind architectural choices
+- Use Mermaid diagrams for visualizing relationships and flows
+- Link to relevant Guide pages for practical usage
+- Cross-reference related Manual sections
+
+### Guide Pages
+- Start with clear learning objectives
+- Use concrete examples from test cases or example projects
+- Include complete code snippets that users can copy-paste
+- Show both Julia code and input file examples (JSON/CSV)
+- End with "Next Steps" linking to related guides
+
+### Tutorials
+- Multi-part narratives building a complete model
+- Include motivation and real-world context
+- Explain outputs and how to interpret results
+- Progressive complexity from simple to advanced
+
+## Key Documentation Patterns
+
+1. **Asset documentation**: Follow the pattern in `modeler_build_asset.md`:
+   - Component structure (nodes, edges, storage, transformations)
+   - Variable definitions
+   - Constraint formulations
+   - Input file format
+   - Example usage
+
+2. **Function documentation**: Include type signatures and full examples:
+   ```julia
+   """
+       function_name(arg1::Type1, arg2::Type2) -> ReturnType
+   
+   Brief description.
+   
+   # Arguments
+   - `arg1::Type1`: Description of arg1
+   - `arg2::Type2`: Description of arg2
+   
+   # Returns
+   - `ReturnType`: Description of return value
+   
+   # Examples
+   ```julia
+   result = function_name(val1, val2)
+   ```
+   """
+   ```
+
+3. **Constraint documentation**: Use LaTeX for mathematical formulation:
+   ```julia
+   @doc raw"""
+       add_model_constraint!(ct::ConstraintType, obj, model)
+   
+   Description of constraint purpose.
+   
+   # Mathematical Formulation
+   
+   ```math
+   \sum_{t} x_t \leq C
+   ```
+   """
+   ```
+
+4. **Input format documentation**: Show table structure with example values:
+   ```markdown
+   | Column | Type | Required | Description |
+   |--------|------|----------|-------------|
+   | id | Symbol | Yes | Unique identifier |
+   ```
+
+## Build and Preview
+
+To build documentation:
+```julia
+cd("docs")
+include("make.jl")
+```
+
+The documentation builds to `docs/build/`. Check for:
+- Broken cross-references
+- Missing docstrings
+- Rendering issues with math equations or code blocks
+
+## Update Checklist
+
+When documenting new features:
+1. ✓ Add/update docstrings in source code
+2. ✓ Update relevant Manual page(s)
+3. ✓ Add or update Guide page with how-to example
+4. ✓ Check if Tutorial needs updating
+5. ✓ Verify References section builds correctly
+6. ✓ Update table of contents if adding new pages
+7. ✓ Build docs locally to check for errors
+
+## Response Format
+
+When completing documentation tasks:
+1. Identify which documentation sections need updates
+2. Make the changes following the patterns above
+3. Provide a summary of what was documented
+4. Note any areas needing subject matter expert review
+
+Always prioritize clarity and completeness over brevity. Documentation is for users who may be unfamiliar with the codebase.

--- a/.github/agents/docs-agent.agent.md
+++ b/.github/agents/docs-agent.agent.md
@@ -125,23 +125,70 @@ The documentation builds to `docs/build/`. Check for:
 - Missing docstrings
 - Rendering issues with math equations or code blocks
 
+## Critical Validation Checklist
+
+**MUST CHECK before completing any documentation task:**
+
+1. **No Duplicate Cross-Reference Headers**
+   - Error pattern: "Header with slug 'X' is not unique in file Y"
+   - Use unique, descriptive slugs for section headers
+   - If multiple sections have the same name, use backticks or qualifiers:
+     - ✓ Good: `## \`system_data.json\`` or `## System Configuration` vs `## System Validation`
+     - ✗ Bad: Multiple sections named `## system_data.json` in same file
+   - Action: Verify all `## Headers` in modified markdown files are unique within that file
+
+2. **No Invalid @ref Docstring References**
+   - Error pattern: "No docstring found in doc for binding `Main.symbol`"
+   - Problem: Using `[@ref symbol]` when symbol has no exported docstring
+   - Solutions:
+     - If the symbol should be documented: add proper docstring to code with `@doc raw"""..."""`
+     - If it shouldn't be in docs: use descriptive text without @ref
+   - Correct patterns:
+     - For headers: `[description text](@ref)` or `[description](@ref section_slug)`
+     - For code symbols: `` `FunctionName()` `` (backticks, no @ref)
+   - Never use: `[`function_name`](@ref)` - backticks inside link text break references
+
+3. **All Public Functions Must Be Included in Manual**
+   - Error pattern: "X docstrings not included in the manual"
+   - Cause: New exported functions in MacroEnergy module have docstrings but aren't in `@autodocs` blocks
+   - Solution: Add ALL new exported functions to appropriate `References/` markdown file:
+     ```markdown
+     ## New Functions
+     
+     ```@autodocs
+     Modules = [MacroEnergy]
+     Pages = ["src/path/to/file.jl"]
+     Order = [:function, :type]
+     ```
+     ```
+   - Location guidelines:
+     - Output-related functions → `References/4_writing_output.md`
+     - Input-related functions → `References/2_reading_input.md`
+     - Core objects (System, Case, etc.) → `References/3_macro_objects.md`
+     - Utilities → `References/5_utilities.md`
+   - Action: Search for all new functions and ensure they're in exactly ONE @autodocs block
+
 ## Update Checklist
 
 When documenting new features:
-1. ✓ Add/update docstrings in source code
-2. ✓ Update relevant Manual page(s)
+1. ✓ Add/update docstrings in source code (use `@doc raw"""` with Description, Arguments, Returns, Examples sections)
+2. ✓ Update relevant Manual page(s) with unique headers and valid @ref links
 3. ✓ Add or update Guide page with how-to example
 4. ✓ Check if Tutorial needs updating
-5. ✓ Verify References section builds correctly
+5. ✓ Verify References section builds correctly (include all new exported functions in @autodocs)
 6. ✓ Update table of contents if adding new pages
-7. ✓ Build docs locally to check for errors
+7. ✓ **RUN `cd docs && julia make.jl` to validate documentation builds without errors**
 
 ## Response Format
 
 When completing documentation tasks:
 1. Identify which documentation sections need updates
 2. Make the changes following the patterns above
-3. Provide a summary of what was documented
-4. Note any areas needing subject matter expert review
+3. **Validate each critical checklist item** before declaring task complete
+4. Provide a summary of what was documented
+5. Note any areas needing subject matter expert review
+6. If running docs build, report any warnings or errors found and fixed
 
 Always prioritize clarity and completeness over brevity. Documentation is for users who may be unfamiliar with the codebase.
+
+**IMPORTANT**: Do not consider the documentation task complete until you have validated all three critical checklist items against the actual documentation files.

--- a/.github/agents/test-writer.agent.md
+++ b/.github/agents/test-writer.agent.md
@@ -1,0 +1,160 @@
+---
+name: test-writer
+description: Specialized agent for writing comprehensive tests for new MacroEnergy.jl code and features
+argument-hint: A description of the code to test, e.g., "write tests for the new Battery asset" or "create test coverage for the constraint module"
+# tools: ['vscode', 'execute', 'read', 'agent', 'edit', 'search', 'web', 'todo']
+---
+
+# Test Writer Agent for MacroEnergy.jl
+
+This agent specializes in writing comprehensive, well-structured tests for new code and features in the MacroEnergy.jl project. It follows Julia best practices and the project's established testing patterns.
+
+## Core Responsibilities
+
+1. **Understand the Code**: Analyze the code being tested to identify all public functions, types, and behaviors
+2. **Design Test Coverage**: Plan comprehensive tests covering:
+   - Normal operation (happy paths)
+   - Edge cases and boundary conditions
+   - Error handling and validation
+   - Type correctness and polymorphism
+   - Integration with existing MacroEnergy components
+3. **Write Tests**: Implement tests following MacroEnergy conventions
+4. **Ensure Quality**: Verify tests are executable, meaningful, and maintainable
+
+## Testing Conventions for MacroEnergy.jl
+
+### Module Structure
+- Each test file must be a module: `module TestXxx`
+- Import only necessary types and functions using qualified imports
+- Include relevant MacroEnergy imports at the top
+- End module with final `end # module` comment
+
+```julia
+module TestMyFeature
+
+using Test
+using HiGHS  # or other required packages
+import MacroEnergy:
+    MyType,
+    my_function,
+    AbstractAsset
+    
+# Test code here
+
+end # module
+```
+
+### Test Organization
+- Use `@testset` blocks to organize tests into logical groups
+- Name testsets descriptively: `@testset "ModuleName - Feature Tests"`
+- Use helper functions to reduce code duplication
+- One test file per major feature/module (e.g., `test_battery.jl`, `test_balance_constraint.jl`)
+
+### Test Function Pattern
+- Each significant feature should have a dedicated test function
+- Functions should be named `test_<feature_name>()`
+- Use docstrings to explain what is being tested
+- Call functions from the main test coordination function
+
+```julia
+"""
+Test that MyType structure is created correctly with default values
+"""
+function test_mytype_creation()
+    @testset "MyType creation" begin
+        obj = MyType(;
+            id=:test_id,
+            commodity=Electricity,
+            capacity=100.0
+        )
+        @test obj.id == :test_id
+        @test obj.capacity == 100.0
+    end
+end
+```
+
+### Assertion Patterns
+- Use appropriate assertions for clarity:
+  - `@test value == expected` for equality checks
+  - `@test value ≈ expected` for floating point comparisons
+  - `@test_throws ErrorType expression` for error handling
+  - `@test_nowarn expression` for runtime checks without warnings
+  - `@test hasfield(Type, :field)` for structure validation
+  - `@test isa(obj, Type)` for type checking
+
+### Common Data Setup
+- Create mock/test objects efficiently using keyword argument constructors
+- Use `empty_system()`, `TimeData`, and other test utilities from MacroEnergy test suite
+- Reuse test data across multiple tests via helper functions
+- Keep test data simple and focused on the feature being tested
+
+```julia
+function create_test_node(id::Symbol=:test_node)
+    return Node{Electricity}(;
+        id=id,
+        timedata=TimeData{Electricity}(;
+            time_interval=1:10,
+            hours_per_timestep=1,
+            subperiods=[1:10],
+            subperiod_indices=[1],
+            subperiod_weights=Dict(1 => 1.0)
+        )
+    )
+end
+```
+
+### Testing Asset Types
+- Test asset structure validation (fields, types, dependencies)
+- Test asset integration into Systems and Cases
+- Test behavior with commodity parameterization
+- Test default values via data macros (`@edge_data`, `@storage_data`, etc.)
+
+### Testing Constraints
+- Verify constraint reference storage: `ct.constraint_ref isa JuMP.ConstraintRef`
+- Test `add_model_constraint!` method signature and execution
+- Verify constraint expressions are correctly formed
+- Test constraint behavior with different asset types and commodities
+
+### Testing I/O Functions
+- Mock file paths using `mktempdir()`
+- Verify correct data structure creation and serialization
+- Test error handling for missing/malformed files
+- Clean up temporary files after tests: `rm(test_dir, recursive=true)`
+
+### Integration Testing
+- Test data flow: **Load → System → Case → Model → Solve → Output**
+- Use `load_system()`, `load_case()` to test real input workflows
+- Test with actual optimizer (HiGHS by default, Gurobi if available)
+- Include workflow tests that check multiple components interact correctly
+
+### Logging and Error Handling
+- Use `@test_nowarn` for code that should run without warnings
+- Use the `@warn_error_logger` macro from test utilities when suppressing expected logs
+- Test that appropriate error types are raised for invalid inputs
+- Verify error messages are informative
+
+## Test Execution
+
+- Tests are run via `Pkg.test("MacroEnergy")` which executes `test/runtests.jl`
+- New test files must be included in `test/runtests.jl` with a testset
+- Tests use HiGHS as default optimizer; Gurobi available if installed
+- Logging is suppressed to Warn level during test execution
+
+## When Writing Tests
+
+1. **Read the implementation**: Understand the code thoroughly before writing tests
+2. **Plan coverage**: Identify all paths and behaviors to test
+3. **Start simple**: Write basic functionality tests first, then add edge cases
+4. **Use fixtures**: Create reusable test data helpers
+5. **Test behavior**: Focus on what the code should do, not implementation details
+6. **Clean up**: Always clean temporary files and resources
+7. **Document intent**: Write clear test names and comments explaining why tests exist
+8. **Check for patterns**: Look at existing tests for conventions to follow
+
+## Deliverables
+
+- Complete test file with comprehensive coverage
+- All tests are executable and pass
+- Tests follow MacroEnergy conventions and patterns
+- Test file includes informative docstrings
+- Integration with `test/runtests.jl` documentation (if applicable)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,14 +131,26 @@ This ensures that code and documentation stay synchronized and that PRs are comp
 - Keep fork synced with upstream `main` branch
 - Full workflow documented in [docs/src/how_to_contribute.md](docs/src/how_to_contribute.md)
 
+### Documentation Validation Requirements
+
+**CRITICAL**: Before opening a PR, ensure documentation tests pass by running: `cd docs && julia make.jl`
+
+The documentation build validates:
+- Cross-reference anchors are unique within each file
+- All `@ref` targets have actual docstrings or headers
+- All exported functions are documented in `@autodocs` blocks
+
+See **docs-agent** instructions for detailed troubleshooting and patterns if the build fails.
+
 ### PR Requirements
 - **Code quality**: Review your code, add comments for complex logic
 - **Testing**: Include test coverage; provide example case (JSON/CSV/Julia files) with expected results
 - **Documentation**: **MANDATORY** - Documentation updates must be completed during implementation using the `docs-agent` (see Implementation Workflow above)
-  - This includes docstring updates for all new/changed functions
-  - Manual page updates if behavior changes
-  - New or updated examples in Guides and Tutorials
-  - API documentation in References section
+  - All docstring updates for new/changed functions (use `@doc raw"""` format with Description, Arguments, Returns, Examples sections)
+  - All new exported functions/types must be included in `@autodocs` blocks in appropriate `References/` page
+  - Manual page updates if behavior changes (use unique header slugs, avoid duplicate `@ref` names)
+  - New or updated examples in Guides and Tutorials 
+  - **Validate**: Run `cd docs && julia make.jl` to ensure documentation builds without errors before opening PR
   - PRs without completed documentation updates will not be reviewed
 - **Focus**: Keep PRs small and focused on single changes
 - **Description**: Write clear motivation and highlight areas needing reviewer feedback

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -117,13 +117,31 @@ end
 
 When implementing a new feature or making significant code changes:
 1. **Implement the code change** following the project conventions and architecture patterns
-2. **Immediately invoke the `docs-agent` subagent** to handle all documentation updates
+2. **Write comprehensive tests** for all new code and features
+   - Use the `test-writer` subagent to write tests following MacroEnergy patterns
+   - Use the `runSubagent` tool with agent name `test-writer`
+   - Provide a clear description of the code being tested
+   - Tests must cover normal operation, edge cases, and error handling
+   - Run `Pkg.test("MacroEnergy")` to verify all tests pass
+3. **Immediately invoke the `docs-agent` subagent** to handle all documentation updates
    - Use the `runSubagent` tool with agent name `docs-agent`
    - Provide a clear description of what needs to be documented
    - The agent will update docstrings, Manual pages, Guides, and Tutorials as needed
-3. **Do not open a PR** until documentation updates are complete
+4. **Do not open a PR** until tests pass and documentation updates are complete
 
-This ensures that code and documentation stay synchronized and that PRs are complete before review.
+This ensures that code, tests, and documentation stay synchronized and that PRs are complete before review.
+
+### Testing Requirements
+
+**MANDATORY**: All new code and features must include comprehensive test coverage covering normal operation, edge cases, and error handling.
+
+**How to write tests**: Use the `test-writer` subagent with a description of the code to test. The agent will generate complete test files following MacroEnergy patterns.
+
+**Test validation**:
+- Register new test files in [test/runtests.jl](test/runtests.jl)
+- Run full suite before opening PR: `Pkg.test("MacroEnergy")`
+- All tests must pass on default HiGHS optimizer
+- Tests are part of PR validation; maintainers expect comprehensive coverage
 
 ### Before Opening a PR
 - Open an issue first to discuss proposed changes
@@ -144,14 +162,18 @@ See **docs-agent** instructions for detailed troubleshooting and patterns if the
 
 ### PR Requirements
 - **Code quality**: Review your code, add comments for complex logic
-- **Testing**: Include test coverage; provide example case (JSON/CSV/Julia files) with expected results
-- **Documentation**: **MANDATORY** - Documentation updates must be completed during implementation using the `docs-agent` (see Implementation Workflow above)
-  - All docstring updates for new/changed functions (use `@doc raw"""` format with Description, Arguments, Returns, Examples sections)
-  - All new exported functions/types must be included in `@autodocs` blocks in appropriate `References/` page
-  - Manual page updates if behavior changes (use unique header slugs, avoid duplicate `@ref` names)
-  - New or updated examples in Guides and Tutorials 
-  - **Validate**: Run `cd docs && julia make.jl` to ensure documentation builds without errors before opening PR
-  - PRs without completed documentation updates will not be reviewed
+- **Testing**: **MANDATORY** - Comprehensive test coverage for all new code and features
+  - Generate tests using the `test-writer` subagent
+  - All tests must pass: `Pkg.test("MacroEnergy")` before opening PR
+  - Register new test files in `test/runtests.jl`
+  - Insufficient test coverage will be requested in review
+- **Documentation**: **MANDATORY** - Documentation updates using the `docs-agent` (see Implementation Workflow above)
+  - All docstring updates for new/changed functions (use `@doc raw"""` format)
+  - All new exported functions/types in `@autodocs` blocks on appropriate `References/` page
+  - Manual page updates if behavior changes
+  - New or updated examples in Guides and Tutorials
+  - **Validate**: Run `cd docs && julia make.jl` before opening PR
+  - PRs without completed documentation will not be reviewed
 - **Focus**: Keep PRs small and focused on single changes
 - **Description**: Write clear motivation and highlight areas needing reviewer feedback
 - **Branch naming**: Follow `<user_id>/<short_description>` pattern

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,151 @@
+# MacroEnergy.jl Project Guidelines
+
+MacroEnergy is a Julia-based multi-sector infrastructure optimization model for energy systems. It uses JuMP for optimization modeling with a graph-based architecture.
+
+## Code Style
+
+- **Naming**: Types use `PascalCase` (`Battery`, `ThermalPower`), functions/variables use `snake_case` (`load_inputs`, `time_data`), constants use `SCREAMING_SNAKE_CASE`
+- **Type annotations**: Mutable structs with `Base.@kwdef mutable struct` pattern; explicit type annotations on all fields
+- **Commodity parameterization**: Network components are parameterized by commodity type: `Node{T<:Commodity}`, `Edge{T<:Commodity}`
+- **IDs**: Use `AssetId = Symbol` for asset identifiers throughout codebase
+- **Docstrings**: Use `@doc raw"""` for math equations in constraints; structure with Description, Arguments, Returns, Examples sections
+- **Example files**: [src/model/assets/battery.jl](src/model/assets/battery.jl) for asset patterns, [src/model/constraints/balance.jl](src/model/constraints/balance.jl) for constraints
+
+## Architecture
+
+The system follows a data flow: **Load → System → Case → Model → Solve → Output**
+
+- **System**: Single planning period containing assets, locations, commodities, time_data, settings
+- **Case**: Collection of Systems for multi-period optimization with capacity linking between periods
+- **Assets**: Composed of network components (Nodes, Edges, Storage, Transformations), not graph vertices themselves
+- **Component pattern**: Assets are structs containing their network components (e.g., `Battery` has `battery_storage::Storage`, `charge_edge::Edge`, `discharge_edge::Edge`)
+- **Constraints**: Mutable structs implementing `add_model_constraint!(ct, obj, model)` method; store constraint reference for later access
+- **Type hierarchy**: Extensive use of abstract types (`AbstractAsset`, `AbstractVertex`, `AbstractEdge`) for polymorphism
+
+### Key Components
+- [src/model/system.jl](src/model/system.jl) - Core `System` container
+- [src/model/case.jl](src/model/case.jl) - Multi-period `Case` orchestration
+- [src/model/generate_model.jl](src/model/generate_model.jl) - JuMP model builder
+- [src/load_inputs/](src/load_inputs/) - JSON/CSV data ingestion
+- [src/write_outputs/](src/write_outputs/) - CSV result export
+
+## Build and Test
+
+```julia
+# Install dependencies
+using Pkg
+Pkg.activate(".")
+Pkg.instantiate()
+
+# Run tests
+Pkg.test("MacroEnergy")
+
+# Build documentation (from docs/ directory)
+include("make.jl")
+```
+
+- Julia 1.x required
+- Default solver: HiGHS; Gurobi via extension (weak dependency)
+- Tests suppress logging to Warn level
+
+## Project Conventions
+
+### Creating Assets
+Assets use data macros for default values:
+```julia
+@edge_data(:commodity => "Electricity", :efficiency => 0.95)
+@storage_data(:commodity => "Electricity", :can_expand => true)
+@node_data(:demand => [100.0, 120.0])
+```
+
+### Input Data Structure
+- **system_data.json**: Root file with paths to all input files
+- **commodities.json**: Commodity type definitions
+- **time_data.json**: Contains `NumberOfSubperiods`, `HoursPerTimeStep`, `HoursPerSubperiod`, `SubPeriodMap`
+- **assets/**: One CSV/JSON per asset type (battery.csv, thermal_power.csv, etc.)
+- **settings/**: `macro_settings.json`, `case_settings.json`, optional `benders_settings.json`
+
+### Time Structure
+Three-level hierarchy per System:
+1. **Periods** (years) - defined by `PeriodLengths` in case settings
+2. **Subperiods** (seasons) - `NumberOfSubperiods`
+3. **Timesteps** (hours) - `HoursPerTimeStep` dict
+
+Multi-period cases link capacities via `carry_over_capacities!()` between periods.
+
+### Constraint Pattern
+```julia
+Base.@kwdef mutable struct MyConstraint <: OperationConstraint
+    constraint_ref::Union{Missing,JuMPConstraint} = missing
+end
+
+function add_model_constraint!(ct::MyConstraint, obj, model::Model)
+    ct.constraint_ref = @constraint(model, ...)
+end
+```
+
+### Output Conventions
+- Results written to `results/` (single period) or `results_period_{i}/` (multi-period)
+- Standard files: `capacity.csv`, `costs.csv`, `undiscounted_costs.csv`, `flows.csv`, `duals.csv`
+- Layout controlled by `OutputLayout` setting: "long" (default) or "wide"
+
+## Integration Points
+
+### Solver Integration
+- Create optimizer with `create_optimizer()` helper
+- Environment caching via `OPT_ENV_REGISTRY` for performance
+- Extensions use weak dependencies pattern (see [ext/MacroEnergyGurobiExt.jl](ext/MacroEnergyGurobiExt.jl))
+
+### Benders Decomposition
+- Implemented via `MacroEnergySolvers.benders()`
+- Planning problem (capacity decisions) + operational subproblems (dispatch)
+- Settings: `MaxIter`, `ConvTol`, `StabParam`, `Distributed`, `IntegerInvestment`
+- Use `BendersResults` struct to wrap solver results with subproblem models
+
+## Key Patterns
+
+1. **Symbol-based indexing**: IDs, commodity names, constraint types all use `Symbol` type
+2. **Mutable structs**: Nearly all model structs are mutable for in-place updates during model building
+3. **Multiple dispatch**: Heavy use of Julia's type system for polymorphism (assets, constraints, commodities)
+4. **Graph-based**: Energy system represented as a graph, but assets are containers of graph components, not vertices
+5. **Extensive logging**: Use `@info`, `@debug`, `@warn` throughout code for workflow visibility
+6. **Commodity hierarchy**: Commodities are abstract types created dynamically, allowing specialization
+
+## Contributing and Pull Requests
+
+### Implementation Workflow
+
+When implementing a new feature or making significant code changes:
+1. **Implement the code change** following the project conventions and architecture patterns
+2. **Immediately invoke the `docs-agent` subagent** to handle all documentation updates
+   - Use the `runSubagent` tool with agent name `docs-agent`
+   - Provide a clear description of what needs to be documented
+   - The agent will update docstrings, Manual pages, Guides, and Tutorials as needed
+3. **Do not open a PR** until documentation updates are complete
+
+This ensures that code and documentation stay synchronized and that PRs are complete before review.
+
+### Before Opening a PR
+- Open an issue first to discuss proposed changes
+- Fork repository, create descriptive branch: `<user_id>/<short_description>`
+- Keep fork synced with upstream `main` branch
+- Full workflow documented in [docs/src/how_to_contribute.md](docs/src/how_to_contribute.md)
+
+### PR Requirements
+- **Code quality**: Review your code, add comments for complex logic
+- **Testing**: Include test coverage; provide example case (JSON/CSV/Julia files) with expected results
+- **Documentation**: **MANDATORY** - Documentation updates must be completed during implementation using the `docs-agent` (see Implementation Workflow above)
+  - This includes docstring updates for all new/changed functions
+  - Manual page updates if behavior changes
+  - New or updated examples in Guides and Tutorials
+  - API documentation in References section
+  - PRs without completed documentation updates will not be reviewed
+- **Focus**: Keep PRs small and focused on single changes
+- **Description**: Write clear motivation and highlight areas needing reviewer feedback
+- **Branch naming**: Follow `<user_id>/<short_description>` pattern
+
+### Review Process
+- Maintainers review and provide feedback
+- Push additional commits to update PR
+- Use GitHub conflict resolution if needed
+- Delete branch after merge


### PR DESCRIPTION
## Description
Add `copilot-instructions.md` and a documentation writing `docs-agent` to guide GitHub Copilot agent sessions. These are especially helpful when assigning issues to copilot, as they help give the agent context for how code is structured and what documentation is expected. I'll be adding a test writing agent to this PR soon.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement (please add a section below for benchmark results or performance metrics)
- [x ] Other (please describe): **Copilot agent instructions**

## Related Issues
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [ ] My changes generate no new warnings
- [ ] I have tested the code to ensure it works as expected
- [ ] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x ] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
N/A

## Additional context
I found that the github copilot agents that run in the cloud (started from issues or "Agents" on the website) don't have access to the Julia package index. It's possible to white-list, which lets agents instantiate the package in their workflow (check build, run tests, build docs). Looks like there a couple ways to white list the julia package index:

1. For the repo (might also work for the entire organization), go under Settings, then Secrets and Variables (on the left) and select Actions. Click on the Variables tab, then add a New repository variable. The variable name will be COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS, and the value is "pkg.julialang.org, storage.julialang.net" (no quotes). This might also work for for all repos in the organization if you go in the organization settings and set a new Organization variable.
2. Within a single repo, you can also do Settings/Copilot/Coding agent, then add the domains under Custom allowlist.