### PR TITLE
HotFix: Discount scaling for duals from Benders

### DIFF
--- a/docs/src/References/4_writing_output.md
+++ b/docs/src/References/4_writing_output.md
@@ -106,11 +106,6 @@ MacroEnergy.write_cost_breakdown_files!
 MacroEnergy.write_duals
 ```
 
-## `write_duals_benders`
-```@docs
-MacroEnergy.write_duals_benders
-```
-
 ## `write_flow`
 
 ```@docs

--- a/src/write_outputs/write_duals.jl
+++ b/src/write_outputs/write_duals.jl
@@ -45,39 +45,6 @@ function write_duals(
 end
 
 """
-    write_duals_benders(
-        results_dir::AbstractString,
-        system::System,
-        scaling::Float64=1.0
-    )
-
-Write dual values for Benders decomposition results.
-
-This function is slightly different than the one for other solution algorithms as the 
-dual values for balance constraints are already undiscounted (the objective function 
-for the operational subproblems is already undiscounted). 
-CO2 cap constraint duals come from the planning problem which is discounted (so scaling is applied).
-
-# Arguments
-- `results_dir::AbstractString`: Directory where CSV files will be written
-- `system::System`: The system containing solved constraints with dual values
-- `scaling::Float64`: Scaling factor for CO2 cap constraint duals (default is 1.0)
-"""
-function write_duals_benders(
-    results_dir::AbstractString,
-    system::System,
-    scaling::Float64=1.0
-)
-    @info "Writing constraint dual values to $results_dir"
-
-    # Duals for Balance and CO2 cap constraints
-    write_balance_duals(results_dir, system, scaling)
-    write_co2_cap_duals(results_dir, system, scaling)
-    
-    return nothing
-end
-
-"""
     write_balance_duals(results_dir::AbstractString, system::System, scaling::Float64=1.0)
 
 Write balance constraint dual values (marginal prices) to CSV file.

--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -124,7 +124,7 @@ function write_outputs(case_path::AbstractString, case::Case, bd_results::Bender
             
             # Scaling factor to account for discounting in multi-period models
             discount_scaling = compute_variable_cost_discount_scaling(period_idx, settings)
-            write_duals_benders(results_dir, period, discount_scaling)
+            write_duals(results_dir, period, discount_scaling)
         end
     end
     	


### PR DESCRIPTION
Because now the cost of the operational subproblems are discounted, duals from Balance constraints need to be scaled to take into account discounting.