### PR TITLE
Add warning if discharge edge on Storage with max and/or min duration constraints doesn't have capacity

### DIFF
--- a/src/model/constraints/storage_duration.jl
+++ b/src/model/constraints/storage_duration.jl
@@ -21,7 +21,11 @@ Add a storage max duration constraint to the storage `g`. The functional form of
 function add_model_constraint!(ct::StorageMaxDurationConstraint, g::AbstractStorage, model::Model)
     e = discharge_edge(g)
 
-    if max_duration(g) > 0
+    if !has_capacity(e)
+        @warn "Discharge edge for storage $(id(g)) does not have capacity. Ignoring max duration constraint."
+    end
+
+    if max_duration(g) > 0 && has_capacity(e)
         ct.constraint_ref =
             @constraint(model, capacity(g) <= max_duration(g) * capacity(e))
     end
@@ -53,7 +57,11 @@ Add a storage min duration constraint to the storage `g`. The functional form of
 function add_model_constraint!(ct::StorageMinDurationConstraint, g::AbstractStorage, model::Model)
     e = discharge_edge(g)
 
-    if max_duration(g) > 0
+    if !has_capacity(e)
+        @warn "Discharge edge for storage $(id(g)) does not have capacity. Ignoring min duration constraint."
+    end
+
+    if min_duration(g) > 0 && has_capacity(e)
         ct.constraint_ref =
             @constraint(model, capacity(g) >= min_duration(g) * capacity(e))
     end


### PR DESCRIPTION
## Description
This PR add a warning if discharge edge on Storage with StorageMaxDurationConstraint or StorageMinDurationConstraint doesn't have capacity.

Currently, `capacity(edge) = AffExpr(0.0)`, so if this is misconfigured then the Storage won't be built as:

```
capacity(storage) <= max_duration(storage) * capacity(edge)
```
Will just set both capacities to 0.0

The same is true for minimum constraints.

I've had Macro add a warning and not apply the constraint, as it can't currently be activated if `capacity(edge) == 0.0` because `capacity(storage)` is non-negative. We could instead have this error.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.