### PR TITLE
Hotfix BlastFurnaceBasicOxygenFurnace

### DIFF
--- a/src/model/assets/integratedblastfurnacebasicoxygenfurnace.jl
+++ b/src/model/assets/integratedblastfurnacebasicoxygenfurnace.jl
@@ -174,7 +174,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         steelscrap_start_node,
         steelscrap_end_node,
     )
-    steelscrap_edge.unidirectional = true
 
     # metalurgical coal edge
 
@@ -205,7 +204,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         metcoal_start_node,
         metcoal_end_node,
     )
-    metcoal_edge.unidirectional = true;
 
     # thermal coal edge
 
@@ -238,7 +236,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         thermalcoal_start_node,
         thermalcoal_end_node,
     )
-    thermalcoal_edge.unidirectional = true;
 
     # natural gas edge
 
@@ -268,7 +265,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         natgas_start_node,
         natgas_end_node,
     )
-    natgas_edge.unidirectional = true;
 
     # electricity edge
 
@@ -297,7 +293,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         elec_start_node,
         elec_end_node,
     )
-    elec_edge.unidirectional = true
 
     # CO2 edge
 
@@ -327,9 +322,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         co2_end_node,
     )
     co2_edge.constraints = Vector{AbstractTypeConstraint}()
-    co2_edge.unidirectional = true;
-
-
 
     # crude steel edge
 
@@ -363,7 +355,6 @@ function make(asset_type::Type{BlastFurnaceBasicOxygenFurnace}, data::AbstractDi
         crudesteel_edge_data,
         :constraints,
         [MustRunConstraint(), CapacityConstraint()])
-    crudesteel_edge.unidirectional = true
 
     # stochiometry
 


### PR DESCRIPTION

## Description
Remove .unidirectional = true lines from BlastFurnaceBasicOxygenFurnace. These are not compatible with the updated Edge types

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Related Issues


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.