### PR TITLE
Hotfix: fix bug for lossy bidirectional edges without a capacity

### DIFF
--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -824,7 +824,9 @@ function update_balance_start!(e::BidirectionalEdge, model::Model)
         flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
         flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
-        @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
+            @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        end
         effective_flow = @expression(model, [t in time_interval(e)], flow_pos[t] - (1 - loss_fraction(e,t)) * flow_neg[t])
     else
         effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))
@@ -844,7 +846,9 @@ function update_balance_end!(e::BidirectionalEdge, model::Model)
         flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
         flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
-        @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
+            @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        end        
         effective_flow = @expression(model, [t in time_interval(e)], (1 - loss_fraction(e,t)) * flow_pos[t] - flow_neg[t])
     else
         effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))


### PR DESCRIPTION
## Description
The current functions wrongly set to zero the flow across lossy bidirectional edges without a capacity variable.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)