### PR TITLE
Update slacks benders

### DIFF
--- a/src/model/benders/operations.jl
+++ b/src/model/benders/operations.jl
@@ -17,8 +17,8 @@ function generate_operation_subproblem(system::System,case_settings::NamedTuple,
     if include_subproblem_slacks == true && !haskey(model, :myslack_max)
         @info("Adding slack variables to ensure subproblems are always feasible")
         slack_penalty = 2*maximum(coefficient(model[:eVariableCost],v) for v in all_variables(model))
-        eq_cons_to_be_relaxed =  get_all_balance_constraints(system);
-        less_ineq_cons_to_be_relaxed = get_all_policy_constraints(system);
+        eq_cons_to_be_relaxed =  get_ldes_constraints_to_relax(system);
+        less_ineq_cons_to_be_relaxed = get_policy_constraints_to_relax(system);
         greater_ineq_cons_to_be_relaxed = Vector{ConstraintRef}();
         add_slack_variables!(model,slack_penalty,eq_cons_to_be_relaxed,less_ineq_cons_to_be_relaxed,greater_ineq_cons_to_be_relaxed)
     end
@@ -215,23 +215,8 @@ function compute_slack_penalty_value(system::System)
 
 end
 
-function get_all_balance_constraints(system::System)
+function get_ldes_constraints_to_relax(system::System)
     balance_constraints = Vector{JuMPConstraint}();
-    for n in system.locations
-        ### Add slacks also when non-served demand is modeled to cover cases where supply is greater than demand
-        if isa(n,Node) #### && isempty(non_served_demand(n)) 
-            for c in n.constraints
-                if isa(c, BalanceConstraint)
-                    for i in balance_ids(n)
-                        for t in time_interval(n)
-                            push!(balance_constraints, c.constraint_ref[i,t])
-                        end
-                    end
-                end
-            end
-        end
-    end 
-
     for a in system.assets
         for t in fieldnames(typeof(a))
             g = getfield(a,t);
@@ -258,7 +243,7 @@ function get_all_balance_constraints(system::System)
 end
 
 
-function get_all_policy_constraints(system::System)
+function get_policy_constraints_to_relax(system::System)
     policy_constraints = Vector{JuMPConstraint}();
     for n in system.locations
         if isa(n,Node) && isempty(n.price_unmet_policy)

--- a/src/model/benders/operations.jl
+++ b/src/model/benders/operations.jl
@@ -14,7 +14,7 @@ function generate_operation_subproblem(system::System,case_settings::NamedTuple,
 
     operation_model!(system, model)
 
-    if include_subproblem_slacks == true
+    if include_subproblem_slacks == true && !haskey(model, :myslack_max)
         @info("Adding slack variables to ensure subproblems are always feasible")
         slack_penalty = 2*maximum(coefficient(model[:eVariableCost],v) for v in all_variables(model))
         eq_cons_to_be_relaxed =  get_all_balance_constraints(system);

--- a/src/model/benders/prepare_benders_run.jl
+++ b/src/model/benders/prepare_benders_run.jl
@@ -103,8 +103,6 @@ function create_worker_process(pid,project,case_path::AbstractString)
         end
     end
 
-    Distributed.remotecall_eval(Main, pid, :(using MacroEnergySolvers))
-
     Distributed.remotecall_eval(MacroEnergy, pid, :(MacroEnergy.load_user_additions($case_path)))
 
 end

--- a/src/model/benders/prepare_benders_run.jl
+++ b/src/model/benders/prepare_benders_run.jl
@@ -51,12 +51,12 @@ function get_period_to_subproblem_mapping(periods::Vector{System})
     
 end
 
-function start_distributed_processes!(number_of_processes::Int64,case_path::AbstractString)
+function start_distributed_processes!(case_path::AbstractString, number_of_subproblems::Int64; lsf_cpus_per_task::Int64=1)
 
     # rmprocs.(workers())
 
     if haskey(ENV,"SLURM_NTASKS")
-        parse(Int, ENV["SLURM_NTASKS"]) > number_of_processes ? @warn("SLURM_NTASKS is greater than the number of processes specified. Only $number_of_processes processes will be used.") : nothing
+        parse(Int, ENV["SLURM_NTASKS"]) > number_of_subproblems ? @warn("SLURM_NTASKS is greater than the number of subproblems specified. Only $number_of_subproblems processes will be used.") : nothing
         cpus_per_task = parse(Int, ENV["SLURM_CPUS_PER_TASK"]);
         addprocs(SlurmClusterManager.SlurmManager(); exeflags=["-t $cpus_per_task"])
     elseif haskey(ENV,"LSB_DJOB_NUMPROC")

--- a/src/model/benders/prepare_benders_run.jl
+++ b/src/model/benders/prepare_benders_run.jl
@@ -59,8 +59,16 @@ function start_distributed_processes!(number_of_processes::Int64,case_path::Abst
         parse(Int, ENV["SLURM_NTASKS"]) > number_of_processes ? @warn("SLURM_NTASKS is greater than the number of processes specified. Only $number_of_processes processes will be used.") : nothing
         cpus_per_task = parse(Int, ENV["SLURM_CPUS_PER_TASK"]);
         addprocs(SlurmClusterManager.SlurmManager(); exeflags=["-t $cpus_per_task"])
+    elseif haskey(ENV,"LSB_DJOB_NUMPROC")
+        lsb_numproc = parse(Int, ENV["LSB_DJOB_NUMPROC"])
+        if lsb_numproc ÷ lsf_cpus_per_task > number_of_subproblems*lsf_cpus_per_task
+            @warn("LSB_DJOB_NUMPROC is greater than the number of subproblems multiplied by number of CPUs per task: number_of_subproblems = $number_of_subproblems, cpus_per_task = $lsf_cpus_per_task, LSB_DJOB_NUMPROC = $lsb_numproc.
+            Only $number_of_subproblems processes will be used.")
+        end
+        number_of_processes= min(lsb_numproc ÷ lsf_cpus_per_task, number_of_subproblems)
+        addprocs(number_of_processes; exeflags=["-t $lsf_cpus_per_task"])
     else
-        ntasks = min(number_of_processes,Sys.CPU_THREADS)
+        ntasks = min(number_of_subproblems,Sys.CPU_THREADS)
         cpus_per_task = 1;
         addprocs(ntasks)
     end

--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -824,7 +824,9 @@ function update_balance_start!(e::BidirectionalEdge, model::Model)
         flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
         flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
-        @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
+            @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        end
         effective_flow = @expression(model, [t in time_interval(e)], flow_pos[t] - (1 - loss_fraction(e,t)) * flow_neg[t])
     else
         effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))
@@ -844,7 +846,9 @@ function update_balance_end!(e::BidirectionalEdge, model::Model)
         flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
         flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
-        @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
+            @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
+        end        
         effective_flow = @expression(model, [t in time_interval(e)], (1 - loss_fraction(e,t)) * flow_pos[t] - flow_neg[t])
     else
         effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))

--- a/src/utilities/run_tools.jl
+++ b/src/utilities/run_tools.jl
@@ -141,7 +141,7 @@ function run_case(
         if isa(solution_algorithm(case), Benders)
             if case.settings.BendersSettings[:Distributed]
                 number_of_subproblems = sum(length(system.time_data[:Electricity].subperiods) for system in case.systems)
-                start_distributed_processes!(number_of_subproblems, case_path)
+                start_distributed_processes!(case_path, number_of_subproblems)
             end
         end
 


### PR DESCRIPTION
## Description
Updates the way we handle the automatic inclusion of slacks in Benders subproblems, restricting the constraints we relax to: 
1) LDES constraints
2) Policy constraints without an `unmet_policy_price`

To be merged after PR #229 and PR #230, as it includes commits from both.

## Type of change

- [x] New feature (non-breaking change which adds functionality)