### PR TITLE
Raise error on invalid CSV column format

### DIFF
--- a/src/load_inputs/load_csv_inputs.jl
+++ b/src/load_inputs/load_csv_inputs.jl
@@ -54,17 +54,17 @@ function validate_csv_data(loaded_csv)::Bool
     headers = loaded_csv.names
     # headers must be at least 2 columns
     if length(headers) < 2
-        @debug("CSV file must have at least 2 columns: type and id")
+        @warn("CSV file must have at least 2 columns: Type and id")
         return false
     end
-    # The first column must be "type"
+    # The first column must be "Type"
     if headers[1] != :Type
-        @debug("The first column of the CSV file must be 'Type'")
+        @warn("The first column of the CSV file must be 'Type' (got '$(headers[1])')")
         return false
     end
     # The second column must be "id"
     if headers[2] != :id
-        @debug("The second column of the CSV file must be 'id'")
+        @warn("The second column of the CSV file must be 'id' (got '$(headers[2])')")
         return false
     end
     return true

--- a/src/load_inputs/load_csv_inputs.jl
+++ b/src/load_inputs/load_csv_inputs.jl
@@ -51,7 +51,7 @@ function load_csv_inputs(file_path::AbstractString; rel_path::AbstractString=dir
 end
 
 function validate_csv_data(loaded_csv)::Bool
-    headers = loaded_csv.names
+    headers = propertynames(loaded_csv)
     # headers must be at least 2 columns
     if length(headers) < 2
         @warn("CSV file must have at least 2 columns: Type and id")
@@ -86,13 +86,19 @@ function insert_data(dict::Dict{Symbol, Any}, keys::Vector{Symbol}, data::Any)
 end
 
 function csv_to_json(file_path::AbstractString, nesting_str::AbstractString="--")::Vector{Dict{Symbol,Any}}
-    data = duckdb_read(file_path)
+    data = DataFrame(duckdb_read(file_path))
+    # Rearrange Type and id to be the first two columns if they exist
+    col_names = propertynames(data)
+    if :Type in col_names && :id in col_names
+        other_cols = [n for n in col_names if n ∉ (:Type, :id)]
+        select!(data, [:Type, :id, other_cols...])
+    end
     if !validate_csv_data(data)
         return Vector{Dict{Symbol,Any}}()
     end
 
     column_map = Dict{Symbol, Any}()
-    for header in data.names
+    for header in propertynames(data)
         props = Symbol.(split(string(header), nesting_str))
         column_map[header] = [:instance_data, props...]
     end
@@ -101,7 +107,7 @@ function csv_to_json(file_path::AbstractString, nesting_str::AbstractString="--"
     column_map[:Type] = [:type]
     
     all_json_data = Vector{Dict{Symbol, Any}}()
-    for row in data
+    for row in eachrow(data)
         json_data = Dict{Symbol, Any}()
         for (col_name, dict_address) in column_map
             insert_data(json_data, dict_address, row[col_name])


### PR DESCRIPTION
## Description
Currently, we silently require for an asset file in CSV format to have "Type" as first column and "id" as second column. This PR attempts to raise an error if that's not the case.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
The error can be reproduced by running the multisector_3zone_simpleCSVinputs example and swapping the second and third column of an asset file. 

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.