### PR TITLE
Copy log file to results folder

### DIFF
--- a/src/model/myopic.jl
+++ b/src/model/myopic.jl
@@ -1,5 +1,6 @@
 struct MyopicResults
     models::Union{Vector{Model}, Nothing}
+    output_path::String
 end
 
 function run_myopic_iteration!(case::Case, opt::Optimizer)
@@ -136,7 +137,7 @@ function run_myopic_iteration!(case::Case, opt::Optimizer)
     @info("Writing settings file")
     write_settings(case, joinpath(output_path, "settings.json"))
 
-    return return_models ? MyopicResults(models) : MyopicResults(nothing)
+    return MyopicResults(return_models ? models : nothing, output_path)
 end
 
 function load_previous_capacity_results(path::AbstractString)

--- a/src/utilities/run_tools.jl
+++ b/src/utilities/run_tools.jl
@@ -149,12 +149,16 @@ function run_case(
 
         postprocess!(case, solution)
 
-        # Myopic outputs are written during iteration, so we don't need to write them here
-        if !isa(solution_algorithm(case), Myopic)
-            if length(case.systems) ≥ 1
-                case_path = create_output_path(case.systems[1], case_path)
-            end
-            write_outputs(case_path, case, solution)
+        if isa(solution, MyopicResults)
+            # Outputs already written per-period during iteration; just retrieve the output path for log file copying
+            output_path = solution.output_path
+        else
+            output_path = length(case.systems) ≥ 1 ? create_output_path(case.systems[1], case_path) : case_path
+            write_outputs(output_path, case, solution)
+        end
+
+        if log_to_file && isfile(log_file_path)
+            cp(log_file_path, joinpath(output_path, basename(log_file_path)); force=true)
         end
 
         # If Benders, delete processes

--- a/test/test_myopic.jl
+++ b/test/test_myopic.jl
@@ -20,12 +20,16 @@ Test MyopicResults structure and basic functionality
 function test_myopic_results_structure()
     @testset "MyopicResults structure" begin
         # Test without models stored (this is the memory-optimized case)
-        results_without_models = MyopicResults(nothing)
+        results_without_models = MyopicResults(nothing, "path/to/output")
         @test isnothing(results_without_models.models)
+        @test results_without_models.output_path == "path/to/output"
         
         # Test field access
         @test hasfield(MyopicResults, :models)
         @test fieldtype(MyopicResults, :models) == Union{Vector{Model}, Nothing}
+
+        @test hasfield(MyopicResults, :output_path)
+        @test fieldtype(MyopicResults, :output_path) == String
         
         # Test that the struct can be created with nothing
         @test isa(results_without_models, MyopicResults)


### PR DESCRIPTION
## Description
This PR adds a copy call in the `run_case` function to copy the log file from the case folder to the results folder for all solution algorithms (Monolithic, Benders, Myopic).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
- Closes #165 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
By running any of the example systems. 

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.