### PR TITLE
Fix documentation on node creation

### DIFF
--- a/docs/src/Guides/User Guide/user_add_node.md
+++ b/docs/src/Guides/User Guide/user_add_node.md
@@ -86,14 +86,14 @@ The most straightforward way of adding a new Node is to use the template functio
 You can add one or more Node by providing the Nodes file as an argument. In these examples, we will assume your have created a system called `ExampleSystems/template_example` and that you have created an `assets` folder in that directory.
 
 ```julia
-julia> template_location("ExampleSystems/template_example/system/nodes.json", Electricity)
-julia> template_location("ExampleSystems/template_example/system/nodes.json", [Electricity, Hydrogen])
+julia> template_node("ExampleSystems/template_example/system/nodes.json", Electricity)
+julia> template_node("ExampleSystems/template_example/system/nodes.json", [Electricity, Hydrogen])
 ```
 
 Or by providing the associated System:
 
 ```julia
-julia> template_location(system, [Electricity, Hydrogen])
+julia> template_node(system, [Electricity, Hydrogen])
 ```
 
 [You can learn how to create or load the System here.](@ref "Creating a new System")


### PR DESCRIPTION
## Description
Documentation on node creation [here](https://macroenergy.github.io/MacroEnergy.jl/stable/Guides/User%20Guide/user_add_node/) had a typo (`template_location` instead of `template_node`). This fixes that.

## Type of change
Please delete options that are not relevant.
- [x] Documentation update

## Related Issues
Fixes #241 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.