### PR TITLE
Fix CSV loading: skip missing cells and fix vec_name typo

### DIFF
--- a/src/load_inputs/load_csv_inputs.jl
+++ b/src/load_inputs/load_csv_inputs.jl
@@ -104,7 +104,9 @@ function csv_to_json(file_path::AbstractString, nesting_str::AbstractString="--"
     for row in data
         json_data = Dict{Symbol, Any}()
         for (col_name, dict_address) in column_map
-            insert_data(json_data, dict_address, row[col_name])
+            val = row[col_name]
+            ismissing(val) && continue  # treat empty CSV cells like absent JSON fields
+            insert_data(json_data, dict_address, val)
         end
         Base.push!(all_json_data, json_data)
     end
@@ -286,7 +288,7 @@ function json_to_csv(json_data::AbstractDict{Symbol, Any}, row_data::RowData=Row
 
     if vec_data.max_length > 0
         fillmissing!(vec_data)
-        write_csv(vec_name.file_path, DataFrame(vec_data.data, vec_data.headers))
+        write_csv(vec_data.file_path, DataFrame(vec_data.data, vec_data.headers))
     end
         
     return row_data


### PR DESCRIPTION
1. Skip missing cells in csv_to_json

When DuckDB reads a CSV file, empty cells are returned as Julia's missing type. Previously, missing was passed directly to insert_data, which would store it in the node's data dictionary. This caused a type mismatch crash downstream when Julia tried to assign missing to a typed field (e.g. Float64 or Dict{DataType, Float64}).

The fix adds ismissing(val) && continue to skip empty cells entirely, treating them the same way JSON loading treats absent fields — the key simply isn't added to the dict, so the node falls back to its default value.

This comes up in practice whenever a CSV file contains heterogeneous nodes — for example, CO2 nodes where only one national node has a rhs_policy value and the remaining regional nodes leave that column empty.

2. Fix vec_name typo in json_to_csv

vec_name was never defined — the correct variable is vec_data. This caused an UndefVarError crash whenever json_to_csv was called with a multi-element timeseries vector.