### PR TITLE
Cache repeated CSV reads

### DIFF
--- a/src/utilities/file_io/csv.jl
+++ b/src/utilities/file_io/csv.jl
@@ -2,15 +2,33 @@
 # CSV file handling
 ###### ###### ###### ###### ###### ######
 
+# Cache full-file reads so that many assets pulling different columns out of
+# the same wide CSV (e.g. hundreds of VRE availability profiles in one file)
+# don't each pay for a fresh DuckDB sniff-and-read of the whole file.
+const _CSV_READ_CACHE = Dict{String,DataFrame}()
+const _CSV_READ_CACHE_LOCK = ReentrantLock()
+
+function _cached_duckdb_read(file_path::AbstractString)::DataFrame
+    key = abspath(file_path)
+    lock(_CSV_READ_CACHE_LOCK) do
+        get!(_CSV_READ_CACHE, key) do
+            DataFrame(duckdb_read(file_path))
+        end
+    end
+end
+
 function read_csv(file_path::AbstractString, select::Vector{Symbol} = Symbol[])::DataFrame
     @debug("Loading CSV data from $file_path")
-    data = DataFrame(duckdb_read(file_path))
+    data = _cached_duckdb_read(file_path)
     if length(select) > 0
         @debug("Loading columns $select from CSV data from $file_path")
-        select!(data, select)
-        isempty(data) && error("Columns $select not found in $file_path")
+        missing_cols = setdiff(select, propertynames(data))
+        isempty(missing_cols) || error("Columns $missing_cols not found in $file_path")
+        # Column-selecting copy: never mutate the cached DataFrame in place,
+        # since it's shared across every caller that reads this file.
+        return data[:, select]
     end
-    return data
+    return copy(data)
 end
 
 function read_csv(file_path::AbstractString, select::Symbol)::DataFrame

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ test_logger = ConsoleLogger(stderr, Logging.Warn)
 
 with_logger(test_logger) do
     Test.@testset verbose = true "Load Inputs" begin
+        include("test_csv_cache.jl")
         include("test_workflow.jl")
         include("test_balance_data.jl")
         include("test_supply_inputs.jl")

--- a/test/test_csv_cache.jl
+++ b/test/test_csv_cache.jl
@@ -1,0 +1,44 @@
+import CSV
+import DataFrames
+
+Test.@testset "CSV read cache" begin
+    mktempdir() do dir
+        path = joinpath(dir, "profiles.csv")
+        CSV.write(
+            path,
+            DataFrames.DataFrame(
+                solar = [0.1, 0.2, 0.3],
+                wind = [0.4, 0.5, 0.6],
+            ),
+        )
+
+        cache_key = abspath(path)
+        lock(MacroEnergy._CSV_READ_CACHE_LOCK) do
+            delete!(MacroEnergy._CSV_READ_CACHE, cache_key)
+        end
+
+        try
+            cached_first = MacroEnergy._cached_duckdb_read(path)
+            cached_second = MacroEnergy._cached_duckdb_read(path)
+            Test.@test cached_first === cached_second
+
+            selected = MacroEnergy.read_csv(path, :solar)
+            Test.@test propertynames(selected) == [:solar]
+            Test.@test selected.solar == [0.1, 0.2, 0.3]
+
+            # A caller may mutate its result without changing the cached data.
+            selected.solar[1] = 99.0
+            Test.@test MacroEnergy.read_csv(path, :solar).solar == [0.1, 0.2, 0.3]
+
+            full = MacroEnergy.read_csv(path)
+            full.wind[1] = 99.0
+            Test.@test MacroEnergy.read_csv(path, :wind).wind == [0.4, 0.5, 0.6]
+
+            Test.@test_throws ErrorException MacroEnergy.read_csv(path, :missing)
+        finally
+            lock(MacroEnergy._CSV_READ_CACHE_LOCK) do
+                delete!(MacroEnergy._CSV_READ_CACHE, cache_key)
+            end
+        end
+    end
+end


### PR DESCRIPTION
## What

- Cache full-file DuckDB CSV reads by absolute file path.
- Reuse the cached DataFrame when assets request different columns from the same wide CSV.
- Return copies so callers cannot mutate cached data.
- Protect cache population with a lock and report missing selected columns explicitly.
- Add focused tests for reuse, column selection, mutation isolation, and missing columns.

## Why

Large cases can have hundreds of assets referencing different columns in the same wide time-series CSV. The existing path reopened, parsed, and materialized the entire file for every asset before selecting one column.

In a controlled reduced case comparison on the feature snapshot where this change was developed, case generation fell from approximately 31,469 seconds to 32.2 seconds. This PR isolates only the CSV cache and its tests on current `main`.

## Validation

- Full `Pkg.test()` suite passed.
  - Load Inputs: 11,344 / 11,344
  - CSV read cache: 6 / 6
- Repeated real-case load tests passed:
  - `test/test_small_case`: 7.276 s first load, 0.281 s second load
  - `test/test_inputs`: 15.106 s first load, 0.334 s second load
  - five-period `test-adam-16-v3-benders`: 29.017 s first load, 2.895 s second load

## Scope and limitations

- The cache is process-local, so distributed workers retain separate caches.
- Cached DataFrames live for the Julia process lifetime.
- Cache keys are absolute paths; overwriting a CSV at the same path during a process will not refresh its cached contents.
