### PR TITLE
Ensure System assets have unique IDs during generate_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project follows Julia package versioning through `Project.toml` release
 ### Fixed
 
 - Fix wacc default preventing fallback to DiscountRate. Omitted `wacc` was silently treated as `0.0` instead of falling back to the case-level `DiscountRate`.
+- Duplicate asset IDs within a system are now rejected during system generation, preventing ambiguous myopic capacity carry-over and late wide-output failures.
 
 ### Documentation
 

--- a/src/load_inputs/generate_system.jl
+++ b/src/load_inputs/generate_system.jl
@@ -40,6 +40,8 @@ function generate_system!(system::System, system_data::AbstractDict{Symbol,Any})
 
     # Load the assets
     load!(system, system_data[:assets])
+    validate_unique_asset_ids(system)
+
     @info("Done generating system. It took $(round(time() - start_time, digits=2)) seconds")
     return nothing
 end
@@ -53,5 +55,36 @@ function generate_system!(
     @info("Generating system from $file_path")
     system_data = load_system_data(file_path, system.data_dirpath; lazy_load = lazy_load)
     generate_system!(periods, system_data)
+    return nothing
+end
+
+function validate_unique_asset_ids(system::System)::Nothing
+    id_counts = Dict{AssetId,Int}()
+
+    for asset in system.assets
+        asset_id = id(asset)
+        id_counts[asset_id] = get(id_counts, asset_id, 0) + 1
+    end
+
+    duplicates = sort!(
+        [(asset_id, count) for (asset_id, count) in id_counts if count > 1];
+        by = first,
+    )
+
+    if isempty(duplicates)
+        return nothing
+    end
+
+    duplicate_ids = join(
+        ["$(asset_id): $(count)x" for (asset_id, count) in duplicates],
+        ", ",
+    )
+
+    throw(ArgumentError(
+        "Duplicate IDs in system inputs.
+        System $(period_index(system)) has duplicate asset IDs: $duplicate_ids. 
+        All asset IDs must be unique within each system.
+        Duplicates are allowed across different systems within a case."
+    ))
     return nothing
 end


### PR DESCRIPTION
## Description

Reject duplicate asset IDs during system generation.
Assets are now validated immediately after loading, before model generation or optimization. If a system contains duplicate IDs, MacroEnergy throws a clear error listing each duplicated ID and its occurrence count.

This prevents ambiguous cross-period asset matching in myopic capacity carry-over and avoids late failures when writing wide-format outputs. Asset IDs may still be reused across different systems/periods.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #274 


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.