### PR TITLE
Improve type stability of JuMP expressions in Macro

### DIFF
--- a/docs/src/Guides/Developer Guide/2_type_hierarchy.md
+++ b/docs/src/Guides/Developer Guide/2_type_hierarchy.md
@@ -23,4 +23,43 @@ print_tree(AbstractAsset)
 print_tree(MacroEnergy.AbstractTypeConstraint)
 ```
 
+### JuMP container types
+
+Macro's variables and constraints are stored on edges, vertices and storage units as JuMP
+containers, and the concrete container type is not the same in every model. The types
+involved are defined in `src/model/jump_containers.jl` and come in two layers.
+
+The **wide** types, `JuMPVariable` and `JuMPConstraint`, are unions over every container 
+JuMP might hand back (`Array`, `DenseAxisArray`, `SparseAxisArray`, and 
+`VariableRef`/`ConstraintRef`). Struct fields are declared with them — 
+`flow::JuMPVariable` on an `Edge`, `non_served_demand::JuMPVariable` on a `Node` — 
+because a field has to accept whichever container the model build actually
+produced. [`array_container`](@ref MacroEnergy.array_container) decides which one: a
+contiguous one-based index set such as `1:24` gets a plain `Array`, anything else gets a
+`DenseAxisArray`. In practice the `Array` fast path is what a
+monolithic model uses everywhere; the `DenseAxisArray` branch exists for Benders
+subproblems, where `generate_decomposed_system` gives each subproblem its own subperiod
+window (`1:168`, `169:336`, `337:504`, …) and only the first one starts at 1.
+
+The **narrow** types — `VarArrayOrDense`, `MatrixVarOrDense`, `AffExprArrayOrDense` — are
+two-member unions covering only the container shapes that can actually occur for
+a given field, and they are what the accessors re-assert down to:
+
+```julia
+flow(e::AbstractEdge, t::Int64) = (flow(e)::VarArrayOrDense)[t]
+storage_level(g::AbstractStorage, t::Int64) = (storage_level(g)::VarArrayOrDense)[t]
+non_served_demand(n::Node, s::Int64, t::Int64) = (non_served_demand(n)::MatrixVarOrDense)[s, t]
+```
+
+Without that assertion the compiler knows only the field's declared type, `JuMPVariable`,
+which is too wide to have a fixed layout. Each element read inside a per-timestep loop then
+has to go through a generic `getindex` that returns its result as a freshly allocated,
+tagged heap object rather than as a value in registers. With the assertion, Julia splits
+the union into its two concrete branches and specializes the read for each, so it produces a
+`VariableRef`/`AffExpr` directly and allocates nothing.
+
+`test/test_container_types.jl` pins each alias against a real macro-built container and
+`test/test_accessor_allocation.jl` asserts the accessors allocate nothing, so a shape that
+drifts fails a test instead of quietly reverting to `Any`.
+
 

--- a/docs/src/References/5_utilities.md
+++ b/docs/src/References/5_utilities.md
@@ -14,6 +14,11 @@ MacroEnergy.all_constraints
 MacroEnergy.all_constraints_types
 ```
 
+## `array_container`
+```@docs
+MacroEnergy.array_container
+```
+
 ## `asset_ids`
 ```@docs
 MacroEnergy.asset_ids
@@ -37,6 +42,11 @@ MacroEnergy.build_period_planning!
 ## `create_output_path`
 ```@docs
 MacroEnergy.create_output_path
+```
+
+## `_dense_axis_array_type`
+```@docs
+MacroEnergy._dense_axis_array_type
 ```
 
 ## `ensure_duals_available!`

--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -101,10 +101,7 @@ const ME_DEPOT_PATH = joinpath(homedir(), ".macroenergy")
 const H2_MWh = 33.33 # MWh per tonne of H2
 const NG_MWh = 0.29307107 # MWh per MMBTU of NG 
 const AssetId = Symbol
-const JuMPConstraint =
-    Union{Array,Containers.DenseAxisArray,Containers.SparseAxisArray,ConstraintRef}
-const JuMPVariable =
-    Union{Array,Containers.DenseAxisArray,Containers.SparseAxisArray,VariableRef}
+# JuMPConstraint / JuMPVariable moved to model/jump_containers.jl
 
 # Load subcommodities from file when MacroEnergy is loaded
 
@@ -166,6 +163,7 @@ include("utilities/utilities.jl")
 include_all_in_folder("utilities/model_converters")
 
 include("model/units.jl")
+include("model/jump_containers.jl")
 include("model/time_management.jl")
 include("model/networks/vertex.jl")
 include("model/networks/node.jl")

--- a/src/model/benders/operations.jl
+++ b/src/model/benders/operations.jl
@@ -89,10 +89,13 @@ function initialize_dist_subproblems!(system_decomp::Vector,opt::Dict,case_setti
 
     subproblems_all = distribute([Dict() for i in 1:length(system_decomp)]);
 
-    @sync for p in workers()
+    # Scatter the decomposed systems across the workers as a DArray
+    systems_dist = distribute(system_decomp, subproblems_all);
+
+    @sync for p in procs(subproblems_all)
         @async @spawnat p begin
             W_local = localindices(subproblems_all)[1];
-            system_local = [system_decomp[k] for k in W_local];
+            system_local = localpart(systems_dist);
             optimizer = create_optimizer(opt[:solver], opt_env(opt[:solver]), opt[:attributes])
             initialize_local_subproblems!(system_local,localpart(subproblems_all),W_local,optimizer,case_settings,include_subproblem_slacks);
         end

--- a/src/model/constraints/co2_cap.jl
+++ b/src/model/constraints/co2_cap.jl
@@ -44,9 +44,10 @@ function add_model_constraint!(ct::CO2CapConstraint, n::Node{CO2}, model::Model)
             lower_bound = 0.0,
             base_name = "v" * string(ct_type) * "_Slack_$(id(n))_period$(period_index(n))"
         )
+        eVariableCost = model[:eVariableCost]::AffExpr
         for w in subperiod_indices(n)
             add_to_expression!(
-                model[:eVariableCost],
+                eVariableCost,
                 subperiod_weight(n, w) * price_unmet_policy(n, ct_type),
                 n.policy_slack_vars[Symbol(string(ct_type) * "_Slack")][w],
             )

--- a/src/model/constraints/ramping_limits.jl
+++ b/src/model/constraints/ramping_limits.jl
@@ -30,23 +30,27 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithoutUC, mod
         return nothing
     end
     if has_capacity(e)
+
+        ti = time_interval(e)
+        sps = subperiods(e)
+
         #### For now these are commented out because we are not modeling reserves
         # reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
         # regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
         eRampUp = @expression(
             model,
-            [t in time_interval(e)],
-            container = array_container(time_interval(e)),
-            flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) -
+            [t in ti],
+            container = array_container(ti),
+            flow(e, t) - flow(e, timestepbefore(t, 1, sps)) -
             ramp_up_fraction(e) * capacity(e)
         )
 
         eRampDown = @expression(
             model,
-            [t in time_interval(e)],
-            container = array_container(time_interval(e)),
-            flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) -
+            [t in ti],
+            container = array_container(ti),
+            flow(e, timestepbefore(t, 1, sps)) - flow(e, t) -
             ramp_down_fraction(e) * capacity(e)
         )
 
@@ -54,7 +58,7 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithoutUC, mod
 
         ct.constraint_ref = @constraint(
             model,
-            [s in [:RampUp, :RampDown], t in time_interval(e)],
+            [s in [:RampUp, :RampDown], t in ti],
             ramp_expr_dict[s][t] <= 0
         )
     end
@@ -85,15 +89,18 @@ for each time `t` in `time_interval(e)` for the edge `e`. The function [`timeste
 """
 function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model::Model)
 
+    ti = time_interval(e)
+    sps = subperiods(e)
+
     #### For now these are commented out because we are not modeling reserves
     # reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
     # regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
     eRampUp = @expression(
         model,
-        [t in time_interval(e)],
-        container = array_container(time_interval(e)),
-        flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) - (
+        [t in ti],
+        container = array_container(ti),
+        flow(e, t) - flow(e, timestepbefore(t, 1, sps)) - (
             ramp_up_fraction(e) * capacity_size(e) * (ucommit(e, t) - ustart(e, t)) +
             min(availability(e, t), max(min_flow_fraction(e), ramp_up_fraction(e))) *
             capacity_size(e) *
@@ -103,9 +110,9 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model:
 
     eRampDown = @expression(
         model,
-        [t in time_interval(e)],
-        container = array_container(time_interval(e)),
-        flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - (
+        [t in ti],
+        container = array_container(ti),
+        flow(e, timestepbefore(t, 1, sps)) - flow(e, t) - (
             ramp_down_fraction(e) * capacity_size(e) * (ucommit(e, t) - ustart(e, t)) -
             min_flow_fraction(e) * capacity_size(e) * ustart(e, t) +
             min(availability(e, t), max(min_flow_fraction(e), ramp_down_fraction(e))) *
@@ -118,7 +125,7 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model:
 
     ct.constraint_ref = @constraint(
         model,
-        [s in [:RampUp, :RampDown], t in time_interval(e)],
+        [s in [:RampUp, :RampDown], t in ti],
         ramp_expr_dict[s][t] <= 0
     )
     return nothing

--- a/src/model/constraints/ramping_limits.jl
+++ b/src/model/constraints/ramping_limits.jl
@@ -31,12 +31,13 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithoutUC, mod
     end
     if has_capacity(e)
         #### For now these are set to zero because we are not modeling reserves
-        reserves_term = @expression(model, [t in time_interval(e)], 0 * model[:vREF])
-        regulation_term = @expression(model, [t in time_interval(e)], 0 * model[:vREF])
+        reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+        regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
         eRampUp = @expression(
             model,
             [t in time_interval(e)],
+            container = array_container(time_interval(e)),
             flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) +
             regulation_term[t] +
             reserves_term[t] - ramp_up_fraction(e) * capacity(e)
@@ -45,6 +46,7 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithoutUC, mod
         eRampDown = @expression(
             model,
             [t in time_interval(e)],
+            container = array_container(time_interval(e)),
             flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - regulation_term[t] +
             reserves_term[timestepbefore(t, 1, subperiods(e))] -
             ramp_down_fraction(e) * capacity(e)
@@ -86,12 +88,13 @@ for each time `t` in `time_interval(e)` for the edge `e`. The function [`timeste
 function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model::Model)
 
     #### For now these are set to zero because we are not modeling reserves
-    reserves_term = @expression(model, [t in time_interval(e)], 0 * model[:vREF])
-    regulation_term = @expression(model, [t in time_interval(e)], 0 * model[:vREF])
+    reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+    regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
     eRampUp = @expression(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) +
         regulation_term[t] +
         reserves_term[t] - (
@@ -105,6 +108,7 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model:
     eRampDown = @expression(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - regulation_term[t] +
         reserves_term[timestepbefore(t, 1, subperiods(e))] - (
             ramp_down_fraction(e) * capacity_size(e) * (ucommit(e, t) - ustart(e, t)) -

--- a/src/model/constraints/ramping_limits.jl
+++ b/src/model/constraints/ramping_limits.jl
@@ -30,25 +30,23 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithoutUC, mod
         return nothing
     end
     if has_capacity(e)
-        #### For now these are set to zero because we are not modeling reserves
-        reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
-        regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+        #### For now these are commented out because we are not modeling reserves
+        # reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+        # regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
         eRampUp = @expression(
             model,
             [t in time_interval(e)],
             container = array_container(time_interval(e)),
-            flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) +
-            regulation_term[t] +
-            reserves_term[t] - ramp_up_fraction(e) * capacity(e)
+            flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) -
+            ramp_up_fraction(e) * capacity(e)
         )
 
         eRampDown = @expression(
             model,
             [t in time_interval(e)],
             container = array_container(time_interval(e)),
-            flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - regulation_term[t] +
-            reserves_term[timestepbefore(t, 1, subperiods(e))] -
+            flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) -
             ramp_down_fraction(e) * capacity(e)
         )
 
@@ -87,17 +85,15 @@ for each time `t` in `time_interval(e)` for the edge `e`. The function [`timeste
 """
 function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model::Model)
 
-    #### For now these are set to zero because we are not modeling reserves
-    reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
-    regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+    #### For now these are commented out because we are not modeling reserves
+    # reserves_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
+    # regulation_term = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), 0 * model[:vREF])
 
     eRampUp = @expression(
         model,
         [t in time_interval(e)],
         container = array_container(time_interval(e)),
-        flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) +
-        regulation_term[t] +
-        reserves_term[t] - (
+        flow(e, t) - flow(e, timestepbefore(t, 1, subperiods(e))) - (
             ramp_up_fraction(e) * capacity_size(e) * (ucommit(e, t) - ustart(e, t)) +
             min(availability(e, t), max(min_flow_fraction(e), ramp_up_fraction(e))) *
             capacity_size(e) *
@@ -109,8 +105,7 @@ function add_model_constraint!(ct::RampingLimitConstraint, e::EdgeWithUC, model:
         model,
         [t in time_interval(e)],
         container = array_container(time_interval(e)),
-        flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - regulation_term[t] +
-        reserves_term[timestepbefore(t, 1, subperiods(e))] - (
+        flow(e, timestepbefore(t, 1, subperiods(e))) - flow(e, t) - (
             ramp_down_fraction(e) * capacity_size(e) * (ucommit(e, t) - ustart(e, t)) -
             min_flow_fraction(e) * capacity_size(e) * ustart(e, t) +
             min(availability(e, t), max(min_flow_fraction(e), ramp_down_fraction(e))) *

--- a/src/model/jump_containers.jl
+++ b/src/model/jump_containers.jl
@@ -1,0 +1,90 @@
+# JuMP container types used throughout the model.
+#
+# Macro JuMP-related types:
+#
+#   * `JuMPVariable` / `JuMPConstraint` are the WIDE types. Struct fields are declared
+#     with them (`flow::JuMPVariable`) because a field must accept whichever container
+#     `array_container` picked at build time.
+#   * `VarArrayOrDense` / `MatrixVarOrDense` / `AffExprArrayOrDense` are the NARROW
+#     types. Accessors re-assert the field down to them (`(flow(e)::VarArrayOrDense)[t]`)
+#     so that reads infer a concrete `VariableRef`/`AffExpr` and allocate nothing.
+#
+# Every member of the narrow unions must stay fully parametrized. Widening one back to
+# an abstract `DenseAxisArray` makes every accessor read infer `Any` and box: the model
+# stays correct and nothing errors, it just costs ~1.67 GB more on an example case.
+# `test/test_accessor_allocation.jl` asserts zero allocation, and
+# `test/test_container_types.jl` pins each derived type against a real model build.
+
+const JuMPConstraint =
+    Union{Array,Containers.DenseAxisArray,Containers.SparseAxisArray,ConstraintRef}
+const JuMPVariable =
+    Union{Array,Containers.DenseAxisArray,Containers.SparseAxisArray,VariableRef}
+
+
+@doc raw"""
+    array_container(interval)
+
+This function returns the appropriate container type for JuMP variables indexed over
+`interval`. For instances, when `interval` is a contiguous, one-based range
+(e.g., `1:24`), it returns `Array`, which allows JuMP to optimize variable storage
+and access. If `interval` is not one-based (e.g., `169:192`),
+it returns `JuMP.Containers.DenseAxisArray`, which is a more general container type
+that can handle non-one-based indexing.
+
+Benders subproblems are the one case where this matters: `generate_decomposed_system`
+reassigns each subproblem's `time_interval` to its own subperiod's window, and only
+the first subperiod happens to start at 1 (e.g. `1:168`, `169:336`, `337:504`, ...).
+The range stays contiguous but isn't one-based.
+"""
+array_container(interval) = first(interval) == 1 ? Array : JuMP.Containers.DenseAxisArray
+
+"""
+    _dense_axis_array_type(T, axes...)
+
+Returns the concrete type of a `JuMP.Containers.DenseAxisArray` with element type
+`T` and axes `axes...`. This is useful for defining type aliases for JuMP containers
+that are indexed over specific ranges, especially when those ranges are not one-based.
+
+JuMP parametrizes the container as `DenseAxisArray{T,N,Ax,L}` where
+`L == typeof(build_lookup.(axes))`, so `L` is fully determined by the axis types and
+never has to be written out. Recovering it through JuMP's own constructor, instead of
+naming JuMP's internal `_AxisLookup` directly, means a change to JuMP's lookup
+representation is picked up automatically rather than silently yielding a type that
+matches nothing.
+
+Only the *types* of `axes` matter, not their values or lengths. Note that `1:24` and
+`Base.OneTo(24)` are `==` but give different container types.
+
+# Examples
+```julia
+julia> _dense_axis_array_type(VariableRef, 1:24)
+JuMP.Containers.DenseAxisArray{VariableRef, 1, Tuple{UnitRange{Int64}}, Tuple{JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}}}
+julia> _dense_axis_array_type(VariableRef, Base.OneTo(24))   # NOT the same as 1:24
+JuMP.Containers.DenseAxisArray{VariableRef, 1, Tuple{Base.OneTo{Int64}}, Tuple{JuMP.Containers._AxisLookup{Base.OneTo{Int64}}}}
+julia> _dense_axis_array_type(AffExpr, 1:3, 1:24)
+JuMP.Containers.DenseAxisArray{AffExpr, 2, Tuple{UnitRange{Int64}, UnitRange{Int64}}, Tuple{JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}, JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}}}
+```
+"""
+function _dense_axis_array_type(::Type{T}, axes...) where {T}
+    data = Array{T}(undef, length.(axes)...)
+    return typeof(JuMP.Containers.DenseAxisArray(data, axes...))
+end
+
+# Macro reaches every index set through a function call:
+#
+#   time_interval(y)                                    -> StepRange{Int64,Int64}
+#   segments_non_served_demand(n), supply_segments(n)   -> Base.OneTo{Int64}
+#
+const _EMPTY_TIME_AXIS = 1:1:0              # as time_interval
+const _EMPTY_SEGMENT_AXIS = Base.OneTo(0)   # as segments_non_served_demand / supply_segments
+
+const DenseVarOverTime = _dense_axis_array_type(VariableRef, _EMPTY_TIME_AXIS)
+const DenseAffExprOverTime = _dense_axis_array_type(AffExpr, _EMPTY_TIME_AXIS)
+const DenseVarOverSegmentTime = _dense_axis_array_type(VariableRef, _EMPTY_SEGMENT_AXIS, _EMPTY_TIME_AXIS)
+
+# Accessor return types for containers built with `array_container`: the plain
+# `Array` fast path in the common case, or the matching `DenseAxisArray` for Benders
+# subproblems beyond the first.
+const VarArrayOrDense = Union{Vector{VariableRef},DenseVarOverTime}
+const MatrixVarOrDense = Union{Matrix{VariableRef},DenseVarOverSegmentTime}
+const AffExprArrayOrDense = Union{Vector{AffExpr},DenseAffExprOverTime}

--- a/src/model/jump_containers.jl
+++ b/src/model/jump_containers.jl
@@ -36,7 +36,7 @@ reassigns each subproblem's `time_interval` to its own subperiod's window, and o
 the first subperiod happens to start at 1 (e.g. `1:168`, `169:336`, `337:504`, ...).
 The range stays contiguous but isn't one-based.
 """
-array_container(interval) = first(interval) == 1 ? Array : JuMP.Containers.DenseAxisArray
+array_container(interval) = (first(interval) == 1 && step(interval) == 1) ? Array : JuMP.Containers.DenseAxisArray
 
 """
     _dense_axis_array_type(T, axes...)

--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -310,7 +310,7 @@ end_vertex(e::AbstractEdge) = e.end_vertex;
 existing_capacity(e::AbstractEdge) = e.existing_capacity;
 fixed_om_cost(e::AbstractEdge) = e.fixed_om_cost;
 flow(e::AbstractEdge) = e.flow;
-flow(e::AbstractEdge, t::Int64) = flow(e)[t];
+flow(e::AbstractEdge, t::Int64) = (flow(e)::VarArrayOrDense)[t];
 has_capacity(e::AbstractEdge) = e.has_capacity;
 id(e::AbstractEdge) = e.id;
 integer_decisions(e::AbstractEdge) = e.integer_decisions;
@@ -496,12 +496,13 @@ function compute_fixed_costs!(e::AbstractEdge, model::Model, cost_type::Symbol=:
 end
 
 function add_operation_model_varcosts!(e::EdgeWithoutUC, model::Model)
-    for t in time_interval(e)
-        w = current_subperiod(e,t)
-        vom_cost = variable_om_cost(e)
-        if vom_cost > 0
+    vom_cost = variable_om_cost(e)
+    if vom_cost > 0
+        eVariableCost = model[:eVariableCost]::AffExpr
+        for t in time_interval(e)
+            w = current_subperiod(e,t)
             add_to_expression!(
-                model[:eVariableCost],
+                eVariableCost,
                 subperiod_weight(e, w) * vom_cost,
                 flow(e, t),
             )
@@ -513,6 +514,7 @@ function operation_model!(e::UnidirectionalEdge, model::Model)
     e.flow = @variable(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         lower_bound = 0.0,
         base_name = "vFLOW_$(id(e))_period$(period_index(e))"
     )
@@ -522,7 +524,7 @@ function operation_model!(e::UnidirectionalEdge, model::Model)
 end
 
 function operation_model!(e::BidirectionalEdge, model::Model)
-    e.flow = @variable(model, [t in time_interval(e)], base_name = "vFLOW_$(id(e))_period$(period_index(e))")
+    e.flow = @variable(model, [t in time_interval(e)], container = array_container(time_interval(e)), base_name = "vFLOW_$(id(e))_period$(period_index(e))")
     update_balances!(e, model)
     add_operation_model_varcosts!(e, model)
     return nothing
@@ -637,34 +639,38 @@ startup_cost(e::EdgeWithUC) = e.startup_cost;
 startup_fuel_consumption(e::EdgeWithUC) = e.startup_fuel_consumption;
 startup_fuel_balance_id(e::EdgeWithUC) = e.startup_fuel_balance_id;
 ucommit(e::EdgeWithUC) = e.ucommit;
-ucommit(e::EdgeWithUC, t::Int64) = ucommit(e)[t];
+ucommit(e::EdgeWithUC, t::Int64) = (ucommit(e)::VarArrayOrDense)[t];
 ushut(e::EdgeWithUC) = e.ushut;
-ushut(e::EdgeWithUC, t::Int64) = ushut(e)[t];
+ushut(e::EdgeWithUC, t::Int64) = (ushut(e)::VarArrayOrDense)[t];
 ustart(e::EdgeWithUC) = e.ustart;
-ustart(e::EdgeWithUC, t::Int64) = ustart(e)[t];
+ustart(e::EdgeWithUC, t::Int64) = (ustart(e)::VarArrayOrDense)[t];
 ##### End of EdgeWithUC interface #####
 
 function add_operation_model_varcosts!(e::EdgeWithUC, model::Model)
-    for t in time_interval(e)
+    vom_cost = variable_om_cost(e)
+    startup_c = startup_cost(e)
+    if vom_cost > 0 || startup_c > 0
+        eVariableCost = model[:eVariableCost]::AffExpr
+        for t in time_interval(e)
 
-        w = current_subperiod(e,t)
-        vom_cost = variable_om_cost(e)
-        if vom_cost > 0
-            add_to_expression!(
-                model[:eVariableCost],
-                subperiod_weight(e, w) * vom_cost,
-                flow(e, t),
-            )
+            w = current_subperiod(e,t)
+            if vom_cost > 0
+                add_to_expression!(
+                    eVariableCost,
+                    subperiod_weight(e, w) * vom_cost,
+                    flow(e, t),
+                )
+            end
+
+            if startup_c > 0
+                add_to_expression!(
+                    eVariableCost,
+                    subperiod_weight(e, w) * startup_c * capacity_size(e),
+                    ustart(e, t),
+                )
+            end
+
         end
-
-        if startup_cost(e) > 0
-            add_to_expression!(
-                model[:eVariableCost],
-                subperiod_weight(e, w) * startup_cost(e) * capacity_size(e),
-                ustart(e, t),
-            )
-        end
-
     end
 end
 
@@ -679,6 +685,7 @@ function operation_model!(e::EdgeWithUC, model::Model)
     e.flow = @variable(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         lower_bound = 0.0,
         base_name = "vFLOW_$(id(e))_period$(period_index(e))"
     )
@@ -686,6 +693,7 @@ function operation_model!(e::EdgeWithUC, model::Model)
     e.ucommit = @variable(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         lower_bound = 0.0,
         base_name = "vCOMMIT_$(id(e))_period$(period_index(e))"
     )
@@ -693,6 +701,7 @@ function operation_model!(e::EdgeWithUC, model::Model)
     e.ustart = @variable(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         lower_bound = 0.0,
         base_name = "vSTART_$(id(e))_period$(period_index(e))"
     )
@@ -700,6 +709,7 @@ function operation_model!(e::EdgeWithUC, model::Model)
     e.ushut = @variable(
         model,
         [t in time_interval(e)],
+        container = array_container(time_interval(e)),
         lower_bound = 0.0,
         base_name = "vSHUT_$(id(e))_period$(period_index(e))"
     )
@@ -814,7 +824,7 @@ function update_startup_fuel_balance!(e::EdgeWithUC)
 
     if haskey(v.balance_data, i) && startup_fuel_consumption(e) > 0
         balance_coeff = -1 * startup_fuel_consumption(e) * capacity_size(e)
-        balance_expr = get_balance(v,i)
+        balance_expr = (get_balance(v,i)::AffExprArrayOrDense)
         for t in time_interval(e)
             add_to_expression!(balance_expr[t], balance_coeff, ustart(e, t))
         end
@@ -824,8 +834,7 @@ function update_startup_fuel_balance!(e::EdgeWithUC)
 
 end
 
-function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effective_flow, outgoing::Bool)
-    # effective_flow is <: AbstractVector{AffExpr} or AbstractVector{VariableRef}
+function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effective_flow::Union{AffExprArrayOrDense,VarArrayOrDense}, outgoing::Bool)
     if outgoing
         flow_dir = -1.0
     else
@@ -834,7 +843,7 @@ function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effect
     for i in keys(v.balance_data)
         data = balance_data(v, i)
         if isempty(data.terms) && data.constant == 0.0
-            balance_expr = get_balance(v, i)
+            balance_expr = (get_balance(v, i)::AffExprArrayOrDense)
             for t in time_interval(e)
                 add_to_expression!(balance_expr[t], flow_dir, effective_flow[t])
             end
@@ -857,7 +866,7 @@ function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effect
             continue
         end
 
-        balance_expr = get_balance(v, i)
+        balance_expr = (get_balance(v, i)::AffExprArrayOrDense)
         if !has_time_varying_coeff
             balance_coeff = flow_dir * scalar_coeff
             if balance_coeff == 0.0
@@ -889,44 +898,44 @@ function update_balance_start!(e::AbstractEdge, model::Model)
     # This implicitly works for UnidirectionalEdge and EdgeWithUC
     # BidirectionalEdge is handled in a separate method
     v = start_vertex(e)
-    effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))
+    effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
     add_flow_to_vertex_balances!(e, v, effective_flow, true)
 end
 
 function update_balance_start!(e::BidirectionalEdge, model::Model)
     v = start_vertex(e)
     if lossy_edge(e)
-        flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
-        flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
+        flow_pos = @variable(model, [t in time_interval(e)], container = array_container(time_interval(e)), lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
+        flow_neg = @variable(model, [t in time_interval(e)], container = array_container(time_interval(e)), lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
         if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
             @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
         end
-        effective_flow = @expression(model, [t in time_interval(e)], flow_pos[t] - (1 - loss_fraction(e,t)) * flow_neg[t])
+        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow_pos[t] - (1 - loss_fraction(e,t)) * flow_neg[t])
     else
-        effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))
+        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
     end
     add_flow_to_vertex_balances!(e, v, effective_flow, true)
 end
 
 function update_balance_end!(e::AbstractEdge, model::Model)
     v = end_vertex(e)
-    effective_flow = @expression(model, [t in time_interval(e)], (1-loss_fraction(e,t)) * flow(e, t))
+    effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), (1-loss_fraction(e,t)) * flow(e, t))
     add_flow_to_vertex_balances!(e, v, effective_flow, false)
 end
 
 function update_balance_end!(e::BidirectionalEdge, model::Model)
     v = end_vertex(e)
     if lossy_edge(e)
-        flow_pos = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
-        flow_neg = @variable(model, [t in time_interval(e)], lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
+        flow_pos = @variable(model, [t in time_interval(e)], container = array_container(time_interval(e)), lower_bound = 0.0, base_name = "vFLOWPOS_$(id(e))_period$(period_index(e))")
+        flow_neg = @variable(model, [t in time_interval(e)], container = array_container(time_interval(e)), lower_bound = 0.0, base_name = "vFLOWNEG_$(id(e))_period$(period_index(e))")
         @constraint(model, [t in time_interval(e)], flow_pos[t] - flow_neg[t] == flow(e, t))
         if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
             @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
         end        
-        effective_flow = @expression(model, [t in time_interval(e)], (1 - loss_fraction(e,t)) * flow_pos[t] - flow_neg[t])
+        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), (1 - loss_fraction(e,t)) * flow_pos[t] - flow_neg[t])
     else
-        effective_flow = @expression(model, [t in time_interval(e)], flow(e, t))
+        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
     end
     add_flow_to_vertex_balances!(e, v, effective_flow, false)
 end

--- a/src/model/networks/node.jl
+++ b/src/model/networks/node.jl
@@ -108,7 +108,7 @@ end
 max_non_served_demand(n::Node) = n.max_nsd;
 max_non_served_demand(n::Node, s::Int64) = max_non_served_demand(n)[s];
 non_served_demand(n::Node) = n.non_served_demand;
-non_served_demand(n::Node, s::Int64, t::Int64) = non_served_demand(n)[s, t];
+non_served_demand(n::Node, s::Int64, t::Int64) = (non_served_demand(n)::MatrixVarOrDense)[s, t];
 policy_budgeting_vars(n::Node) = n.policy_budgeting_vars;
 policy_slack_vars(n::Node) = n.policy_slack_vars;
 policy_budgeting_constraints(n::Node) = n.policy_budgeting_constraints;
@@ -121,15 +121,23 @@ price_unmet_policy(n::Node) = n.price_unmet_policy;
 price_unmet_policy(n::Node, c::DataType) = price_unmet_policy(n)[c];
 rhs_policy(n::Node) = n.rhs_policy;
 rhs_policy(n::Node, c::DataType) = rhs_policy(n)[c];
-segments_non_served_demand(n::Node) = 1:length(n.max_nsd);
+segments_non_served_demand(n::Node) = Base.OneTo(length(n.max_nsd));
 supply_flow(n::Node) = n.supply_flow;
-supply_flow(n::Node, s::Int64, t::Int64) = supply_flow(n)[s, t];
+supply_flow(n::Node, s::Int64, t::Int64) = (supply_flow(n)::MatrixVarOrDense)[s, t];
 supply(n::Node) = n.supply;
 supply_segment_names(n::Node) = collect(keys(supply(n)));
-supply_segment_name(n::Node, s::Int64) = supply_segment_names(n)[s];
-supply_segments(n::Node) = eachindex(supply_segment_names(n));
+function supply_segment_name(n::Node, s::Int64)
+    for (i, k) in enumerate(keys(supply(n)))
+        i == s && return k
+    end
+    error("supply_segment_name: no segment $s for node $(id(n))")
+end
+supply_segments(n::Node) = Base.OneTo(length(supply(n)));
 min_supply(n::Node) = [segment.min for segment in values(supply(n))];
-min_supply(n::Node, segment_name::Symbol) = get(supply(n), segment_name, SupplySegment(price=Float64[], min=[0.0], max=[Inf])).min;
+function min_supply(n::Node, segment_name::Symbol)
+    seg = supply(n)
+    return haskey(seg, segment_name) ? seg[segment_name].min : [0.0]
+end
 min_supply(n::Node,s::Int64) = min_supply(n, supply_segment_name(n, s));
 min_supply(n::Node, s::Int64, t::Int64) = length(min_supply(n, s)) == 1 ? min_supply(n, s)[1] : min_supply(n, s)[t];
 max_supply(n::Node) = [segment.max for segment in values(supply(n))];
@@ -185,9 +193,11 @@ function operation_model!(n::Node, model::Model)
     build_balance_expressions!(n, model)
 
     if !all(max_non_served_demand(n) .== 0)
+        eVariableCost = model[:eVariableCost]::AffExpr
         n.non_served_demand = @variable(
             model,
             [s in segments_non_served_demand(n), t in time_interval(n)],
+            container = array_container(time_interval(n)),
             lower_bound = 0.0,
             base_name = "vNSD_$(id(n))_period$(period_index(n))"
         )
@@ -195,7 +205,7 @@ function operation_model!(n::Node, model::Model)
             w = current_subperiod(n,t)
             for s in segments_non_served_demand(n)
                 add_to_expression!(
-                    model[:eVariableCost],
+                    eVariableCost,
                     subperiod_weight(n, w) * price_non_served_demand(n, s),
                     non_served_demand(n, s, t),
                 )
@@ -205,10 +215,12 @@ function operation_model!(n::Node, model::Model)
     end
 
     if !isempty(supply_segments(n))
+        eVariableCost = model[:eVariableCost]::AffExpr
 
         n.supply_flow = @variable(
             model,
             [s in supply_segments(n) ,t in time_interval(n)],
+            container = array_container(time_interval(n)),
             lower_bound = 0.0,
             base_name = "vSUPPLY_$(id(n))_period$(period_index(n))"
         )
@@ -226,7 +238,7 @@ function operation_model!(n::Node, model::Model)
                     @constraint(model, sf <= max_sf)
                 end
 
-                add_to_expression!(model[:eVariableCost], subperiod_weight(n,w) * price_supply(n,s,t), sf)
+                add_to_expression!(eVariableCost, subperiod_weight(n,w) * price_supply(n,s,t), sf)
 
                 add_to_expression!(get_balance(n, :demand, t), sf)
             end
@@ -242,10 +254,11 @@ function initialize_balance_expression(n::Node, balance_id::Symbol, model::Model
         return @expression(
             model,
             [t in time_interval(n)],
+            container = array_container(time_interval(n)),
             -demand(n, t) * model[:vREF]
         )
     end
-    return @expression(model, [t in time_interval(n)], 0 * model[:vREF])
+    return @expression(model, [t in time_interval(n)], container = array_container(time_interval(n)), 0 * model[:vREF])
 end
 
 

--- a/src/model/networks/storage.jl
+++ b/src/model/networks/storage.jl
@@ -218,7 +218,7 @@ retirement_period(g::AbstractStorage) = g.retirement_period;
 retrofitted_capacity_track(g::AbstractStorage,s::Int64) = 0.0; ### Note that retrofits are not implemented for storage yet
 spillage_edge(g::AbstractStorage) = g.spillage_edge;
 storage_level(g::AbstractStorage) = g.storage_level;
-storage_level(g::AbstractStorage, t::Int64) = storage_level(g)[t];
+storage_level(g::AbstractStorage, t::Int64) = (storage_level(g)::VarArrayOrDense)[t];
 wacc(g::AbstractStorage) = g.wacc;
 annualized_investment_cost(g::AbstractStorage) = g.annualized_investment_cost;
 pv_period_investment_cost(g::AbstractStorage) = g.pv_period_investment_cost;
@@ -280,6 +280,7 @@ function operation_model!(g::Storage, model::Model)
     g.storage_level = @variable(
         model,
         [t in time_interval(g)],
+        container = array_container(time_interval(g)),
         lower_bound = 0.0,
         base_name = "vSTOR_$(g.id)_period$(period_index(g))"
     )
@@ -396,6 +397,7 @@ function operation_model!(g::LongDurationStorage, model::Model)
     g.storage_level = @variable(
         model,
         [t in time_interval(g)],
+        container = array_container(time_interval(g)),
         lower_bound = 0.0,
         base_name = "vSTOR_$(g.id)_period$(period_index(g))"
     )
@@ -424,12 +426,13 @@ function initialize_balance_expression(g::Storage, balance_id::Symbol, model::Mo
         return @expression(
             model,
             [t in time_interval(g)],
+            container = array_container(time_interval(g)),
             -storage_level(g, t) +
             (1 - loss_fraction(g, timestepbefore(t, 1, subperiods(g)))) *
             storage_level(g, timestepbefore(t, 1, subperiods(g)))
         )
     end
-    return @expression(model, [t in time_interval(g)], 0 * model[:vREF])
+    return @expression(model, [t in time_interval(g)], container = array_container(time_interval(g)), 0 * model[:vREF])
 end
 
 function initialize_balance_expression(g::LongDurationStorage, balance_id::Symbol, model::Model)
@@ -438,6 +441,7 @@ function initialize_balance_expression(g::LongDurationStorage, balance_id::Symbo
         return @expression(
             model,
             [t in time_interval(g)],
+            container = array_container(time_interval(g)),
             if t in starts
                 -storage_level(g, t) +
                 (1 - loss_fraction(g, timestepbefore(t, 1, subperiods(g)))) *
@@ -449,7 +453,7 @@ function initialize_balance_expression(g::LongDurationStorage, balance_id::Symbo
             end
         )
     end
-    return @expression(model, [t in time_interval(g)], 0 * model[:vREF])
+    return @expression(model, [t in time_interval(g)], container = array_container(time_interval(g)), 0 * model[:vREF])
 end
 
 function compute_investment_costs!(g::AbstractStorage, model::Model, cost_type::Function=pv_period_investment_cost)

--- a/src/model/networks/vertex.jl
+++ b/src/model/networks/vertex.jl
@@ -78,7 +78,7 @@ Get the normalized balance definition for a specific balance equation in a verte
 demand_data = balance_data(elec_node, :demand)
 ```
 """
-function balance_data(v::AbstractVertex, i::Symbol)
+function balance_data(v::AbstractVertex, i::Symbol)::BalanceData
     data = v.balance_data[i]
     if data isa BalanceData
         return data
@@ -120,7 +120,7 @@ demand_expr = get_balance(elec_node, :demand)
 ```
 """
 get_balance(v::AbstractVertex, i::Symbol) = v.operation_expr[i]
-get_balance(v::AbstractVertex, i::Symbol, t::Int64) = get_balance(v, i)[t]
+get_balance(v::AbstractVertex, i::Symbol, t::Int64) = (get_balance(v, i)::AffExprArrayOrDense)[t]
 
 """
     all_constraints(v::AbstractVertex)
@@ -272,7 +272,7 @@ function balance_macro_coeff(v::AbstractVertex, obj, var::Symbol, coeff)
 end
 
 function initialize_balance_expression(v::AbstractVertex, balance_id::Symbol, model::Model)
-    return @expression(model, [t in time_interval(v)], 0 * model[:vREF])
+    return @expression(model, [t in time_interval(v)], container = array_container(time_interval(v)), 0 * model[:vREF])
 end
 
 function balance_term_added_by_edge_updates(term::BalanceTerm)
@@ -366,7 +366,7 @@ function local_balance_terms(data::BalanceData)
 end
 
 function compile_balance_data!(v::AbstractVertex, balance_id::Symbol, model::Model)
-    expr = v.operation_expr[balance_id]
+    expr = (v.operation_expr[balance_id]::AffExprArrayOrDense)
     data = balance_data(v, balance_id)
     terms = local_balance_terms(data)
     for (time_index, t) in enumerate(time_interval(v))

--- a/src/model/time_management.jl
+++ b/src/model/time_management.jl
@@ -12,8 +12,14 @@ end
 
 
 ######### TimeData interface #########
-current_subperiod(y::Union{AbstractVertex,AbstractEdge}, t::Int64) =
-    subperiod_indices(y)[findfirst(t .∈ subperiods(y))];
+function current_subperiod(y::Union{AbstractVertex,AbstractEdge}, t::Int64)
+    for (idx, w) in enumerate(subperiods(y))
+        if t in w
+            return subperiod_indices(y)[idx]
+        end
+    end
+    error("current_subperiod: time $t not found in any subperiod")
+end
 commodity_type(n::TimeData{T}) where {T} = T;
 get_subperiod(y::Union{AbstractVertex,AbstractEdge}, w::Int64) = subperiods(y)[findfirst(subperiod_indices(y).==w)];
 hours_per_timestep(y::Union{AbstractVertex,AbstractEdge}) = y.timedata.hours_per_timestep;
@@ -38,11 +44,12 @@ Determines the time step that is `h` steps before index `t` in subperiod `p` wit
 
 """
 function timestepbefore(t::Int, h::Int, subperiods::Vector{StepRange{Int64,Int64}})::Int
-    #Find the subperiod that contains time t
-    w = subperiods[findfirst(t .∈ subperiods)]
-    #circular shift of the subperiod forward by h steps
-    wc = circshift(w, h)
-
-    return wc[findfirst(w .== t)]
-
+    # Find the subperiod that contains time t, and index t within it circularly, h steps back
+    for w in subperiods
+        if t in w
+            n = length(w)
+            return first(w) + mod(t - first(w) - h, n)
+        end
+    end
+    error("timestepbefore: time $t not found in any subperiod")
 end

--- a/src/model/time_management.jl
+++ b/src/model/time_management.jl
@@ -38,7 +38,7 @@ total_hours_modeled(y::Union{AbstractVertex,AbstractEdge}) = y.timedata.total_ho
 
 
 @doc raw"""
-    timestepbefore(t::Int, h::Int,subperiods::Vector{StepRange{Int64,Int64})
+    timestepbefore(t::Int, h::Int,subperiods::Vector{StepRange{Int64,Int64}})
 
 Determines the time step that is `h` steps before index `t` in subperiod `p` with circular indexing.
 

--- a/src/model/time_management.jl
+++ b/src/model/time_management.jl
@@ -47,8 +47,9 @@ function timestepbefore(t::Int, h::Int, subperiods::Vector{StepRange{Int64,Int64
     # Find the subperiod that contains time t, and index t within it circularly, h steps back
     for w in subperiods
         if t in w
-            n = length(w)
-            return first(w) + mod(t - first(w) - h, n)
+            step_size = step(w)
+            offset = (t - first(w)) ÷ step_size
+            return first(w) + step_size * mod(offset - h, length(w))
         end
     end
     error("timestepbefore: time $t not found in any subperiod")

--- a/test/asset_tests/asset_test_utilities.jl
+++ b/test/asset_tests/asset_test_utilities.jl
@@ -31,12 +31,17 @@ export MOI,
     make_test_timedata,
     push_locations!
 
-function make_test_timedata(::Type{T}, num_steps::Int = 3) where {T}
+function make_test_timedata(::Type{T}, num_steps::Int = 3; start::Int = 1) where {T}
+    # `start` != 1 mimics a Benders subproblem's time_interval: generate_decomposed_system
+    # (src/model/benders/prepare_benders_run.jl) reassigns each subproblem's time_interval
+    # to its own subperiod's absolute window (e.g. 169:336 for the second week), not a
+    # locally-renumbered 1:168 — so it stays contiguous but isn't one-based.
+    interval = start:(start + num_steps - 1)
     return TimeData{T}(;
-        time_interval = 1:num_steps,
+        time_interval = interval,
         hours_per_timestep = 1,
         period_index = 1,
-        subperiods = [1:num_steps],
+        subperiods = [interval],
         subperiod_indices = [1],
         subperiod_weights = Dict(1 => 1.0),
         subperiod_map = Dict(1 => 1),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,5 +82,11 @@ with_logger(test_logger) do
     Test.@testset verbose = true "Myopic Functionality" begin
         include("test_myopic.jl")
     end
+
+    Test.@testset verbose = true "Container Types and Accessors" begin
+        include("test_container_types.jl")
+        include("test_accessor_allocation.jl")
+        include("test_node_supply_accessors.jl")
+    end
     return nothing
 end

--- a/test/test_accessor_allocation.jl
+++ b/test/test_accessor_allocation.jl
@@ -1,0 +1,178 @@
+module TestAccessorAllocation
+
+using Test
+using JuMP
+using HiGHS
+using MacroEnergy
+
+include("asset_tests/asset_test_utilities.jl")
+using .AssetTestUtilities
+
+import MacroEnergy:
+    array_container,
+    Battery,
+    Electricity,
+    EdgeWithUC,
+    flow,
+    get_balance,
+    make,
+    storage_level,
+    time_interval,
+    ucommit,
+    ushut,
+    ustart
+
+function make_battery_fixture()
+    system = make_test_system([Electricity]; num_steps = 24)
+    elec_timedata = system.time_data[:Electricity]
+
+    source = make_supply_node(Electricity, :battery_source, elec_timedata, fill(1.0, 24))
+    sink = make_demand_node(Electricity, :battery_sink, elec_timedata, fill(1.0, 24))
+    push_locations!(system, source, sink)
+
+    battery_data = Dict{Symbol,Any}(
+        :id => :battery_test,
+        :storage_can_expand => false,
+        :storage_can_retire => false,
+        :discharge_can_expand => false,
+        :discharge_can_retire => false,
+        :charge_can_expand => false,
+        :charge_can_retire => false,
+        :storage_existing_capacity => 10.0,
+        :discharge_existing_capacity => 10.0,
+        :charge_existing_capacity => 10.0,
+        :charge_efficiency => 0.8,
+        :discharge_efficiency => 0.5,
+        :charge_start_vertex => :battery_source,
+        :discharge_end_vertex => :battery_sink,
+    )
+    asset = make(Battery, battery_data, system)
+    push!(system.assets, asset)
+    model = build_test_model(system)
+
+    return (; system, asset, model, sink)
+end
+
+# These accessors must allocate nothing
+const ALLOWED_ACCESSOR_ALLOCATION = 0
+
+function test_flow_allocation()
+    fx = make_battery_fixture()
+    e = fx.asset.charge_edge
+    flow(e, 1)  # warm-up / compile
+    bytes = @allocated flow(e, 1)
+    @info "flow(e,t) allocated $(bytes) bytes"
+    @test flow(e, 1) isa VariableRef
+    @test bytes <= ALLOWED_ACCESSOR_ALLOCATION
+    return nothing
+end
+
+function test_storage_level_allocation()
+    fx = make_battery_fixture()
+    g = fx.asset.battery_storage
+    storage_level(g, 1)
+    bytes = @allocated storage_level(g, 1)
+    @info "storage_level(g,t) allocated $(bytes) bytes"
+    @test storage_level(g, 1) isa VariableRef
+    @test bytes <= ALLOWED_ACCESSOR_ALLOCATION
+    return nothing
+end
+
+function test_get_balance_allocation()
+    fx = make_battery_fixture()
+    v = fx.sink
+    get_balance(v, :demand, 1)
+    bytes = @allocated get_balance(v, :demand, 1)
+    @info "get_balance(v,i,t) allocated $(bytes) bytes"
+    @test get_balance(v, :demand, 1) isa AffExpr
+    @test bytes == 0
+    return nothing
+end
+
+# `start` mimics a Benders subproblem's time_interval (see make_test_timedata):
+# start=1 is the common/Monolithic/Myopic case and Benders' first subproblem;
+# start!=1 is every other Benders subproblem
+function make_uc_edge_fixture(; start::Int = 1)
+    model = Model(HiGHS.Optimizer)
+    set_silent(model)
+
+    timedata = make_test_timedata(Electricity, 24; start = start)
+    dummy_start = make_free_node(Electricity, :uc_start, timedata)
+    dummy_end = make_free_node(Electricity, :uc_end, timedata)
+
+    e = EdgeWithUC{Electricity}(;
+        id = :uc_test_edge,
+        timedata = timedata,
+        start_vertex = dummy_start,
+        end_vertex = dummy_end,
+    )
+    # array_container matches operation_model! exactly: container = Array only
+    # when time_interval(e) is one-based, else JuMP.Containers.DenseAxisArray.
+    c = array_container(time_interval(e))
+    e.flow = @variable(model, [t in time_interval(e)], container = c, lower_bound = 0.0)
+    e.ucommit = @variable(model, [t in time_interval(e)], container = c, lower_bound = 0.0)
+    e.ustart = @variable(model, [t in time_interval(e)], container = c, lower_bound = 0.0)
+    e.ushut = @variable(model, [t in time_interval(e)], container = c, lower_bound = 0.0)
+    return e
+end
+
+function test_uc_accessor_allocation()
+    e = make_uc_edge_fixture()
+
+    ucommit(e, 1); ustart(e, 1); ushut(e, 1)  # warm-up / compile
+
+    b_ucommit = @allocated ucommit(e, 1)
+    b_ustart = @allocated ustart(e, 1)
+    b_ushut = @allocated ushut(e, 1)
+    @info "ucommit/ustart/ushut allocated $(b_ucommit)/$(b_ustart)/$(b_ushut) bytes"
+
+    @test ucommit(e, 1) isa VariableRef
+    @test ustart(e, 1) isa VariableRef
+    @test ushut(e, 1) isa VariableRef
+    @test flow(e) isa Vector{VariableRef}
+    @test b_ucommit <= ALLOWED_ACCESSOR_ALLOCATION
+    @test b_ustart <= ALLOWED_ACCESSOR_ALLOCATION
+    @test b_ushut <= ALLOWED_ACCESSOR_ALLOCATION
+    return nothing
+end
+
+function test_array_container()
+    @test array_container(1:24) === Array
+    @test array_container(169:192) === JuMP.Containers.DenseAxisArray
+    return nothing
+end
+
+function test_uc_accessor_non_one_based()
+    e = make_uc_edge_fixture(; start = 169)
+
+    @test flow(e) isa JuMP.Containers.DenseAxisArray
+    @test flow(e, 169) isa VariableRef
+    @test ucommit(e, 169) isa VariableRef
+    @test ustart(e, 169) isa VariableRef
+    @test ushut(e, 169) isa VariableRef
+    @test_throws KeyError flow(e, 1)  # 1 isn't a valid index for this subproblem's window
+    return nothing
+end
+
+@testset "Accessor allocation" begin
+    @testset "flow(e,t)" begin
+        test_flow_allocation()
+    end
+    @testset "storage_level(g,t)" begin
+        test_storage_level_allocation()
+    end
+    @testset "get_balance(v,i,t)" begin
+        test_get_balance_allocation()
+    end
+    @testset "ucommit/ustart/ushut(e,t)" begin
+        test_uc_accessor_allocation()
+    end
+    @testset "array_container" begin
+        test_array_container()
+    end
+    @testset "Non-one-based time_interval (Benders subproblem) container fallback" begin
+        test_uc_accessor_non_one_based()
+    end
+end
+
+end # module TestAccessorAllocation

--- a/test/test_accessor_allocation.jl
+++ b/test/test_accessor_allocation.jl
@@ -138,6 +138,7 @@ end
 
 function test_array_container()
     @test array_container(1:24) === Array
+    @test array_container(1:2:23) === JuMP.Containers.DenseAxisArray
     @test array_container(169:192) === JuMP.Containers.DenseAxisArray
     return nothing
 end

--- a/test/test_container_types.jl
+++ b/test/test_container_types.jl
@@ -1,0 +1,230 @@
+module TestContainerTypes
+
+
+using Test
+using JuMP
+using HiGHS
+using MacroEnergy
+
+import MacroEnergy:
+    AbstractEdge,
+    AbstractStorage,
+    AbstractVertex,
+    AffExprArrayOrDense,
+    DenseAffExprOverTime,
+    DenseVarOverSegmentTime,
+    DenseVarOverTime,
+    MatrixVarOrDense,
+    Node,
+    VarArrayOrDense,
+    array_container,
+    flow,
+    get_balance,
+    non_served_demand,
+    segments_non_served_demand,
+    storage_level,
+    supply_flow,
+    supply_segments,
+    time_interval,
+    ucommit,
+    ushut,
+    ustart
+
+const CASE_PATH = joinpath(@__DIR__, "test_small_case", "system_data.json")
+
+# Index-set accessors with the same *return types* as the real ones in Macro, so the
+# containers below go through the identical (non-literal) macro path.
+fake_time_interval(first_t, n) = first_t:1:(first_t + n - 1)   # StepRange, as TimeData
+fake_segments(n) = Base.OneTo(n)  # as segments_non_served_demand / supply_segments
+unitrange_segments(n) = 1:n       # the shape both segment accessors must NOT return
+
+# The real accessors must keep agreeing with each other and with `fake_segments`.
+function test_segment_accessors_agree()
+    n = first(filter(x -> x isa Node, first(load_case(CASE_PATH).systems).locations))
+    @test typeof(segments_non_served_demand(n)) === Base.OneTo{Int64}
+    @test typeof(supply_segments(n)) === Base.OneTo{Int64}
+    @test typeof(fake_segments(2)) === typeof(segments_non_served_demand(n))
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# 1. Derived types match what the JuMP macros really produce
+# ---------------------------------------------------------------------------
+function test_derived_types_match_jump()
+    model = Model()
+
+    # Benders subproblem shape: contiguous but not one-based -> DenseAxisArray.
+    ti = fake_time_interval(169, 24)
+    @test array_container(ti) === JuMP.Containers.DenseAxisArray
+
+    v1d = @variable(model, [t in ti], container = array_container(ti))
+    e1d = @expression(model, [t in ti], container = array_container(ti), 1.0 * v1d[t])
+    v2d = @variable(
+        model,
+        [s in fake_segments(3), t in ti],
+        container = array_container(ti)
+    )
+
+    @test typeof(v1d) === DenseVarOverTime
+    @test typeof(e1d) === DenseAffExprOverTime
+    @test typeof(v2d) === DenseVarOverSegmentTime
+
+    # A `UnitRange` segment axis is a *different* container type, even though `1:3`
+    # and `Base.OneTo(3)` are `==`.
+    v2d_unitrange =
+        @variable(model, [s in unitrange_segments(3), t in ti], container = array_container(ti))
+    @test typeof(v2d_unitrange) !== DenseVarOverSegmentTime
+    @test !(v2d_unitrange isa MatrixVarOrDense)
+
+    # ...and every one of them is a member of the union its accessor asserts.
+    @test v1d isa VarArrayOrDense
+    @test e1d isa AffExprArrayOrDense
+    @test v2d isa MatrixVarOrDense
+
+    # One-based (Monolithic/Myopic, and Benders' first subproblem) -> plain Array.
+    ti1 = fake_time_interval(1, 24)
+    @test array_container(ti1) === Array
+    w1d = @variable(model, [t in ti1], container = array_container(ti1))
+    w2d = @variable(
+        model,
+        [s in fake_segments(3), t in ti1],
+        container = array_container(ti1)
+    )
+    @test typeof(w1d) === Vector{VariableRef}
+    @test typeof(w2d) === Matrix{VariableRef}
+    @test w1d isa VarArrayOrDense
+    @test w2d isa MatrixVarOrDense
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# 2. Accessors infer concretely and do not allocate, on BOTH branches
+# ---------------------------------------------------------------------------
+# Loops are monomorphic and accumulate the MOI index so the read cannot be elided;
+# `@allocated` over a splatting/closure harness measures the harness, not the read.
+read_1d(c, t, n) = (a = 0; for _ = 1:n; a += ((c::VarArrayOrDense)[t]).index.value; end; a)
+read_2d(c, s, t, n) = (a = 0; for _ = 1:n; a += ((c::MatrixVarOrDense)[s, t]).index.value; end; a)
+
+function test_accessors_are_concrete_and_free()
+    @test Base.return_types(read_1d, (VarArrayOrDense, Int, Int))[1] === Int
+    @test Base.return_types(read_2d, (MatrixVarOrDense, Int, Int, Int))[1] === Int
+
+    model = Model()
+    ti_dense = fake_time_interval(169, 24)
+    ti_flat = fake_time_interval(1, 24)
+
+    dense_1d = @variable(model, [t in ti_dense], container = array_container(ti_dense))
+    flat_1d = @variable(model, [t in ti_flat], container = array_container(ti_flat))
+    dense_2d = @variable(model, [s in fake_segments(3), t in ti_dense], container = array_container(ti_dense))
+    flat_2d = @variable(model, [s in fake_segments(3), t in ti_flat], container = array_container(ti_flat))
+
+    n = 1_000
+    for (c, t) in ((dense_1d, 169), (flat_1d, 1))
+        read_1d(c, t, 10)
+        @test (@allocated read_1d(c, t, n)) == 0
+    end
+    for (c, t) in ((dense_2d, 169), (flat_2d, 1))
+        read_2d(c, 1, t, 10)
+        @test (@allocated read_2d(c, 1, t, n)) == 0
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# 3. Every container in a real generated model is a union member
+# ---------------------------------------------------------------------------
+# If a new asset or vertex ever introduces a fourth container shape, this 
+# fails instead of silently de-optimizing every accessor that touches it.
+function collect_components(case)
+    edges, storages, nodes, vertices = AbstractEdge[], AbstractStorage[], Node[], AbstractVertex[]
+    for system in case.systems
+        for n in system.locations
+            n isa Node && push!(nodes, n)
+            n isa AbstractVertex && push!(vertices, n)
+        end
+        for a in system.assets, f in fieldnames(typeof(a))
+            v = getfield(a, f)
+            v isa AbstractEdge && push!(edges, v)
+            v isa AbstractStorage && push!(storages, v)
+            v isa AbstractVertex && push!(vertices, v)
+        end
+    end
+    return (; edges, storages, nodes, vertices)
+end
+
+function test_real_model_containers()
+    case = load_case(CASE_PATH)
+    alg = MacroEnergy.solution_algorithm(case)
+    opt = create_optimizer(HiGHS.Optimizer, nothing, ("solver" => "ipm",))
+    MacroEnergy.generate_model(case, opt, alg)
+
+    c = collect_components(case)
+    @test !isempty(c.edges)
+    @test !isempty(c.vertices)
+
+    n_flow = n_uc = n_level = n_nsd = n_supply = n_balance = 0
+    for e in c.edges
+        isempty(flow(e)) && continue
+        @test flow(e) isa VarArrayOrDense
+        @test flow(e, first(time_interval(e))) isa VariableRef
+        n_flow += 1
+        if e isa MacroEnergy.EdgeWithUC && !isempty(ucommit(e))
+            for acc in (ucommit, ustart, ushut)
+                @test acc(e) isa VarArrayOrDense
+                @test acc(e, first(time_interval(e))) isa VariableRef
+            end
+            n_uc += 1
+        end
+    end
+    for g in c.storages
+        isempty(storage_level(g)) && continue
+        @test storage_level(g) isa VarArrayOrDense
+        @test storage_level(g, first(time_interval(g))) isa VariableRef
+        n_level += 1
+    end
+    for n in c.nodes
+        if !isempty(non_served_demand(n))
+            @test non_served_demand(n) isa MatrixVarOrDense
+            @test non_served_demand(n, first(segments_non_served_demand(n)), first(time_interval(n))) isa VariableRef
+            n_nsd += 1
+        end
+        if !isempty(supply_flow(n))
+            @test supply_flow(n) isa MatrixVarOrDense
+            @test supply_flow(n, first(supply_segments(n)), first(time_interval(n))) isa VariableRef
+            n_supply += 1
+        end
+    end
+    for v in c.vertices, (bid, expr) in v.operation_expr
+        @test expr isa AffExprArrayOrDense
+        @test get_balance(v, bid, first(time_interval(v))) isa AffExpr
+        n_balance += 1
+    end
+
+    # The walk must actually have covered each container kind, otherwise the asserts
+    # above are vacuous and a broken union would still pass.
+    @info "container coverage" n_flow n_uc n_level n_nsd n_supply n_balance
+    @test n_flow > 0
+    @test n_uc > 0
+    @test n_level > 0
+    @test n_nsd > 0        # both exercise DenseVarOverSegmentTime's shape
+    @test n_supply > 0
+    @test n_balance > 0
+    return nothing
+end
+
+@testset "Container types" begin
+    @testset "Segment accessors agree" begin
+        test_segment_accessors_agree()
+    end
+    @testset "Derived types match JuMP" begin
+        test_derived_types_match_jump()
+    end
+    @testset "Accessors concrete and allocation-free" begin
+        test_accessors_are_concrete_and_free()
+    end
+    @testset "Real generated model" begin
+        test_real_model_containers()
+    end
+end
+
+end # module TestContainerTypes

--- a/test/test_node_supply_accessors.jl
+++ b/test/test_node_supply_accessors.jl
@@ -1,0 +1,127 @@
+module TestNodeSupplyAccessors
+
+using Test
+using JuMP
+using MacroEnergy
+
+include("asset_tests/asset_test_utilities.jl")
+using .AssetTestUtilities
+
+import MacroEnergy:
+    BalanceConstraint,
+    BalanceData,
+    Electricity,
+    Node,
+    TimeData,
+    max_supply,
+    min_supply,
+    non_served_demand,
+    price_supply,
+    supply_flow,
+    supply_segment_name,
+    supply_segments
+
+function make_supply_test_node()
+    timedata = make_test_timedata(Electricity, 3)
+    return make_supply_node(Electricity, :test_supply_node, timedata, [1.0, 10.0, 2.0])
+end
+
+function test_supply_accessor_correctness()
+    n = make_supply_test_node()
+
+    @test supply_segment_name(n, 1) == :grid
+    @test collect(supply_segments(n)) == [1]
+    @test min_supply(n, 1) == [0.0]
+    @test max_supply(n, 1) == [Inf]
+    @test price_supply(n, 1) == [1.0, 10.0, 2.0]
+    @test min_supply(n, 1, 1) == 0.0
+    @test max_supply(n, 1, 2) == Inf
+    @test price_supply(n, 1, 3) == 2.0
+
+    return n
+end
+
+function test_supply_accessor_allocation()
+    n = make_supply_test_node()
+
+    supply_segment_name(n, 1)
+    min_supply(n, 1, 1)
+    max_supply(n, 1, 1)
+    price_supply(n, 1, 1)  # warm-up / compile
+
+    b_name = @allocated supply_segment_name(n, 1)
+    b_min = @allocated min_supply(n, 1, 1)
+    b_max = @allocated max_supply(n, 1, 1)
+    b_price = @allocated price_supply(n, 1, 1)
+    @info "supply_segment_name/min_supply/max_supply/price_supply allocated $(b_name)/$(b_min)/$(b_max)/$(b_price) bytes"
+
+    @test b_name == 0
+    @test b_min == 0
+    @test b_max == 0
+    @test b_price == 0
+    return nothing
+end
+
+function make_supply_flow_fixture()
+    timedata = make_test_timedata(Electricity, 3)
+    source = make_supply_node(Electricity, :sf_source, timedata, [1.0, 10.0, 2.0])
+    system = make_test_system([Electricity]; num_steps = 3)
+    push_locations!(system, source)
+    model = build_test_model(system)
+    return (; system, model, source)
+end
+
+function test_supply_flow_allocation()
+    fx = make_supply_flow_fixture()
+    n = fx.source
+    supply_flow(n, 1, 1)  # warm-up / compile
+    bytes = @allocated supply_flow(n, 1, 1)
+    @info "supply_flow(n,s,t) allocated $(bytes) bytes"
+    @test supply_flow(n, 1, 1) isa VariableRef
+    @test bytes == 0
+    return nothing
+end
+
+function make_non_served_demand_fixture()
+    timedata = make_test_timedata(Electricity, 3)
+    sink = Node{Electricity}(;
+        id = :nsd_sink,
+        timedata = timedata,
+        constraints = [BalanceConstraint()],
+        balance_data = Dict(:demand => BalanceData()),
+        demand = [1.0, 1.0, 1.0],
+        max_nsd = [1000.0],
+    )
+    system = make_test_system([Electricity]; num_steps = 3)
+    push_locations!(system, sink)
+    model = build_test_model(system)
+    return (; system, model, sink)
+end
+
+function test_non_served_demand_allocation()
+    fx = make_non_served_demand_fixture()
+    n = fx.sink
+    non_served_demand(n, 1, 1)  # warm-up / compile
+    bytes = @allocated non_served_demand(n, 1, 1)
+    @info "non_served_demand(n,s,t) allocated $(bytes) bytes"
+    @test non_served_demand(n, 1, 1) isa VariableRef
+    @test bytes == 0
+    return nothing
+end
+
+@testset "Node supply accessors" begin
+    @testset "correctness" begin
+        test_supply_accessor_correctness()
+    end
+    @testset "allocation" begin
+        test_supply_accessor_allocation()
+    end
+    @testset "supply_flow allocation" begin
+        test_supply_flow_allocation()
+    end
+    @testset "non_served_demand allocation" begin
+        test_non_served_demand_allocation()
+    end
+end
+
+end # module TestNodeSupplyAccessors

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -6,6 +6,29 @@ using MacroEnergy
 using CSV
 using DataFrames
 using OrderedCollections: OrderedDict
+using JuMP
+using HiGHS
+
+include("utilities.jl")
+
+"""
+    fixed_vars(model::Model, values::AbstractArray{Float64})
+
+Build a JuMP variable in `model` for each entry of `values` (preserving its
+shape), fixed to that exact value. Meant for tests that need a real
+`VariableRef` (so `value(...)` and strictly-typed accessors work) but want
+the ergonomics of a plain numeric literal, e.g.
+`flow = fixed_vars(model, [1.0, 2.0, 3.0])` instead of `flow = [1.0, 2.0, 3.0]`.
+"""
+function fixed_vars(model::Model, values::AbstractArray{Float64})
+    vars = similar(values, VariableRef)
+    for i in eachindex(values)
+        vars[i] = @variable(model)
+        fix(vars[i], values[i]; force = true)
+    end
+    return vars
+end
+
 import MacroEnergy:
     TimeData,
     compute_annualized_costs!,
@@ -77,6 +100,8 @@ import MacroEnergy:
 
 
 function test_writing_output()
+    model = Model(HiGHS.Optimizer)
+    set_silent(model)
 
     # Mock objects to use in tests
     node1 = Node{Electricity}(;
@@ -94,8 +119,8 @@ function test_writing_output()
             :seg2 => MacroEnergy.SupplySegment(price = [110.0], min = [0.0], max = [110.0]),
             :seg3 => MacroEnergy.SupplySegment(price = [120.0], min = [0.0], max = [120.0]),
         ),
-        supply_flow = [12.0 15.0 18.0; 0.0 0.0 0.0; 0.0 0.0 0.0],
-        non_served_demand = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0],
+        supply_flow = fixed_vars(model, [12.0 15.0 18.0; 0.0 0.0 0.0; 0.0 0.0 0.0]),
+        non_served_demand = fixed_vars(model, [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]),
         max_nsd=[10.0, 11.0, 12.0],
         price_nsd = [100.0, 110.0, 120.0],
     )
@@ -121,7 +146,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         new_capacity=100.0,
-        storage_level=[1.0, 2.0, 3.0]
+        storage_level=fixed_vars(model, [1.0, 2.0, 3.0])
     )
 
     transformation = Transformation(;
@@ -147,7 +172,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=100.0,
-        flow=[1.0, 2.0, 3.0]
+        flow=fixed_vars(model, [1.0, 2.0, 3.0])
     )
 
     edge_to_storage = UnidirectionalEdge{Electricity}(;
@@ -162,7 +187,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=101.0,
-        flow=[4.0, 5.0, 6.0]
+        flow=fixed_vars(model, [4.0, 5.0, 6.0])
     )
 
     edge_to_transformation = UnidirectionalEdge{Electricity}(;
@@ -178,7 +203,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=102.0,
-        flow=[7.0, 8.0, 9.0]
+        flow=fixed_vars(model, [7.0, 8.0, 9.0])
     )
 
     edge_from_storage = UnidirectionalEdge{Electricity}(;
@@ -193,7 +218,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=103.0,
-        flow=[10.0, 11.0, 12.0]
+        flow=fixed_vars(model, [10.0, 11.0, 12.0])
     )
 
     edge_from_transformation = UnidirectionalEdge{Electricity}(;
@@ -208,7 +233,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=104.0,
-        flow=[13.0, 14.0, 15.0]
+        flow=fixed_vars(model, [13.0, 14.0, 15.0])
     )
 
     edge_storage_transformation = UnidirectionalEdge{Electricity}(;
@@ -223,7 +248,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=105.0,
-        flow=[16.0, 17.0, 18.0]
+        flow=fixed_vars(model, [16.0, 17.0, 18.0])
     )
 
     edge_from_transformation1 = UnidirectionalEdge{NaturalGas}(;
@@ -238,7 +263,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=102.0,
-        flow=[7.0, 8.0, 9.0]
+        flow=fixed_vars(model, [7.0, 8.0, 9.0])
     )
 
     edge_from_transformation2 = UnidirectionalEdge{CO2}(;
@@ -253,7 +278,7 @@ function test_writing_output()
             subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
         ),
         capacity=102.0,
-        flow=[7.0, 8.0, 9.0]
+        flow=fixed_vars(model, [7.0, 8.0, 9.0])
     )
 
     asset1 = ThermalPower(:asset1, transformation, edge_to_transformation, edge_from_transformation1, edge_from_transformation2)
@@ -277,6 +302,8 @@ function test_writing_output()
     add!(system, node2)
     add!(system, asset1)
     add!(system, asset2)
+
+    optimize!(model)
 
     @testset "Helper Functions Tests" begin
         # Test get_commodity_name for a vertex
@@ -485,6 +512,8 @@ function test_writing_output()
     end
 
     @testset "Non-Served Demand Output Functions Tests" begin
+        model = Model(HiGHS.Optimizer)
+        set_silent(model)
         # Create nodes with non-served demand variables
         node_with_nsd = Node{Electricity}(;
             id=:node_nsd,
@@ -496,9 +525,10 @@ function test_writing_output()
                 subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
             ),
             max_nsd=[0.1, 0.2],  # 2 segments
-            non_served_demand=[1.0 2.0 3.0; 4.0 5.0 6.0]  # 2 segments × 3 time steps
+            non_served_demand=fixed_vars(model, [1.0 2.0 3.0; 4.0 5.0 6.0])  # 2 segments × 3 time steps
         )
-        
+        optimize!(model)
+
         # Test get_optimal_non_served_demand for single node
         result = get_optimal_non_served_demand(node_with_nsd, 1.0)
         @test result isa DataFrame
@@ -541,9 +571,10 @@ function test_writing_output()
                 subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
             ),
             max_nsd=[0.1],  # 1 segment
-            non_served_demand=reshape([7.0, 8.0, 9.0], 1, 3)  # 1 segment × 3 time steps
+            non_served_demand=fixed_vars(model, reshape([7.0, 8.0, 9.0], 1, 3))  # 1 segment × 3 time steps
         )
-        
+        optimize!(model)
+
         result_multi = get_optimal_non_served_demand([node_with_nsd, node_with_nsd2], 1.0)
         @test size(result_multi, 1) == 9  # 6 from node1 + 3 from node2
         
@@ -563,6 +594,8 @@ function test_writing_output()
     end
 
     @testset "Storage Level Output Functions Tests" begin
+        model = Model(HiGHS.Optimizer)
+        set_silent(model)
         # Create storage with storage_level values
         storage_for_test = Storage{Electricity}(;
             id=:storage_test,
@@ -573,9 +606,10 @@ function test_writing_output()
                 subperiod_indices=[1, 2, 3],
                 subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
             ),
-            storage_level=[10.0, 20.0, 30.0]
+            storage_level=fixed_vars(model, [10.0, 20.0, 30.0])
         )
-        
+        optimize!(model)
+
         # Test get_optimal_storage_level for single storage (without asset map)
         result = get_optimal_storage_level(storage_for_test, 1.0)
         @test result isa DataFrame
@@ -613,9 +647,10 @@ function test_writing_output()
                 subperiod_indices=[1, 2, 3],
                 subperiod_weights=Dict(1 => 0.3, 2 => 0.5, 3 => 0.2)
             ),
-            storage_level=[40.0, 50.0, 60.0]
+            storage_level=fixed_vars(model, [40.0, 50.0, 60.0])
         )
-        
+        optimize!(model)
+
         result_multi = get_optimal_storage_level([storage_for_test, storage_for_test2], 1.0)
         @test size(result_multi, 1) == 6  # 3 from storage1 + 3 from storage2
         @test result_multi[4, :component_id] == :storage_test2
@@ -656,6 +691,8 @@ function test_writing_output()
     end
 
     @testset "Curtailment Output Functions Tests" begin
+        model = Model(HiGHS.Optimizer)
+        set_silent(model)
         # Create VRE asset with edge that has capacity, flow, and availability
         vre_timedata = TimeData{Electricity}(;
             time_interval=1:3,
@@ -675,9 +712,10 @@ function test_writing_output()
             timedata=vre_timedata,
             has_capacity=true,
             capacity=100.0,
-            flow=[1.0, 2.0, 3.0],
+            flow=fixed_vars(model, [1.0, 2.0, 3.0]),
             availability=[0.5, 0.6, 0.7]
         )
+        optimize!(model)
         vre_asset = VRE(:vre_asset, vre_transform, vre_edge)
 
         # System with VRE for curtailment tests

--- a/test/test_timedata.jl
+++ b/test/test_timedata.jl
@@ -129,6 +129,12 @@ function test_timestepbefore_correctness()
     @test timestepbefore(8760, 1, big_subperiods) == 8759
     @test timestepbefore(4380, 100, big_subperiods) == 4280
 
+    # Stepped ranges must return a timestep within the subperiod.
+    stepped_subperiods = [1:2:9]
+    @test timestepbefore(5, 1, stepped_subperiods) == 3
+    @test timestepbefore(1, 1, stepped_subperiods) == 9
+    @test timestepbefore(1, 5, stepped_subperiods) == 1
+
     return nothing
 end
 

--- a/test/test_timedata.jl
+++ b/test/test_timedata.jl
@@ -3,6 +3,7 @@ module TestTimeData
 using Test
 import MacroEnergy: TimeData, Hydrogen, NaturalGas, Electricity
 import MacroEnergy: load_time_data, load_subperiod_map!, validate_and_set_default_total_hours_modeled!
+import MacroEnergy: timestepbefore, current_subperiod, Node
 
 include("utilities.jl")
 
@@ -108,5 +109,78 @@ time_data_true_with_total_hours_modeled  = Dict{Symbol,TimeData}(
     :Electricity => TimeData{Electricity}(time_interval=1:1:504, hours_per_timestep=1, subperiods=[1:1:168, 169:1:336, 337:1:504], subperiod_indices=[6, 17, 32], subperiod_weights=Dict(6 => 21, 17 =>  13, 32 => 18), subperiod_map=subperiod_map, total_hours_modeled=8736)
 )
 test_load_time_data()
+
+function test_timestepbefore_correctness()
+    subperiods = [1:1:168, 169:1:336, 337:1:504]
+
+    @test timestepbefore(50, 0, subperiods) == 50
+    @test timestepbefore(50, 5, subperiods) == 45
+    # wraparound at the start of a subperiod
+    @test timestepbefore(1, 1, subperiods) == 168
+    @test timestepbefore(169, 1, subperiods) == 336
+    @test timestepbefore(337, 1, subperiods) == 504
+    # shift larger than the subperiod length (multiple wraps)
+    @test timestepbefore(169, 168, subperiods) == 169
+    @test timestepbefore(169, 169, subperiods) == 336
+
+    # single large subperiod, matching a full-year (8760h) case
+    big_subperiods = [1:1:8760]
+    @test timestepbefore(1, 1, big_subperiods) == 8760
+    @test timestepbefore(8760, 1, big_subperiods) == 8759
+    @test timestepbefore(4380, 100, big_subperiods) == 4280
+
+    return nothing
+end
+
+function test_timestepbefore_allocation()
+    subperiods = [1:1:8760]
+    timestepbefore(100, 1, subperiods)  # warm up / compile before measuring
+    bytes = @allocated timestepbefore(100, 1, subperiods)
+    @info "timestepbefore allocated $(bytes) bytes for a single call over an 8760-length subperiod"
+    @test bytes == 0
+    return bytes
+end
+
+@testset "timestepbefore" begin
+    test_timestepbefore_correctness()
+    test_timestepbefore_allocation()
+end
+
+function test_current_subperiod_correctness()
+    subperiods = [1:1:168, 169:1:336, 337:1:504]
+    n = Node{Electricity}(;
+        id = :test_node,
+        timedata = TimeData{Electricity}(;
+            time_interval = 1:504,
+            subperiods = subperiods,
+            subperiod_indices = [10, 20, 30],
+            subperiod_weights = Dict(10 => 1.0, 20 => 1.0, 30 => 1.0),
+            subperiod_map = Dict(1 => 1),
+        ),
+    )
+
+    @test current_subperiod(n, 1) == 10
+    @test current_subperiod(n, 168) == 10
+    @test current_subperiod(n, 169) == 20
+    @test current_subperiod(n, 336) == 20
+    @test current_subperiod(n, 337) == 30
+    @test current_subperiod(n, 504) == 30
+
+    return n
+end
+
+function test_current_subperiod_allocation()
+    n = test_current_subperiod_correctness()
+    current_subperiod(n, 100)  # warm-up / compile
+    bytes = @allocated current_subperiod(n, 100)
+    @info "current_subperiod(y,t) allocated $(bytes) bytes"
+    @test bytes == 0
+    return nothing
+end
+
+@testset "current_subperiod" begin
+    test_current_subperiod_correctness()
+    test_current_subperiod_allocation()
+end
 
 end # module TestTimeData


### PR DESCRIPTION
## Description
This PR attempts to improve type stability in Macro (+ a few additional changes to increase performance). The benchmarks include the example systems and a larger case with full year resolution. Number of allocations from the non-JuMP part of the code is reduced, as well as model generation time. 

## Type of change

- [x] Performance improvement 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.