### PR TITLE
Fix myopic `ReturnModels` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project follows Julia package versioning through `Project.toml` release
 
 ### Fixed
 
+- Myopic runs with `MyopicSettings.ReturnModels = false` now actually free each period's model. Each period's references are now released once its results have been written, and the model is emptied. Results are unchanged; scalar capacities remain readable on the returned `Case` as `Float64`.
 - Fix wacc default preventing fallback to DiscountRate. Omitted `wacc` was silently treated as `0.0` instead of falling back to the case-level `DiscountRate`.
 - Duplicate asset IDs within a system are now rejected during system generation, preventing ambiguous myopic capacity carry-over and late wide-output failures.
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ const pages = [
         "Developer Guide" => [
             "Creating a Constraint" => "Guides/Developer Guide/dev_create_constraint.md",
             "Type Hierarchy" => "Guides/Developer Guide/2_type_hierarchy.md",
+            "Running the Test Suite" => "Guides/Developer Guide/dev_running_tests.md",
         ],
     ],
     "Assets" => "Assets/assets_guide.md",

--- a/docs/src/Guides/Developer Guide/dev_running_tests.md
+++ b/docs/src/Guides/Developer Guide/dev_running_tests.md
@@ -1,0 +1,61 @@
+# Running the Test Suite
+
+Macro's tests are split into two suites:
+
+- **`short`** (the default) — everything except the tests that build and solve full cases. It is what CI runs on pull requests, and what you should run while iterating locally.
+- **`long`** — the short suite plus the slow, full-case tests.
+
+## Running the tests
+
+From the root of the repository:
+
+```bash
+# short suite (default)
+julia --project=. test/runtests.jl
+
+# long suite
+julia --project=. test/runtests.jl long
+```
+
+Or from the Julia REPL, using `Pkg`:
+
+```julia
+using Pkg
+Pkg.test("MacroEnergy")                          # short suite
+Pkg.test("MacroEnergy"; test_args=["long"])      # long suite
+```
+
+The suite can also be selected with the `MACRO_TEST_SUITE` environment variable, which is convenient in scripts and CI:
+
+```bash
+MACRO_TEST_SUITE=long julia --project=. test/runtests.jl
+```
+
+Command-line arguments take precedence over the environment variable. `runtests.jl` logs which suite it is running at startup.
+
+## Adding a test to the long suite
+
+The suite flag is defined in `test/utilities.jl`, which exposes `run_long_tests()`. To keep a slow test out of the short suite, guard the call to it:
+
+```julia
+function run_my_tests()
+    @testset "My Tests" begin
+        test_something_fast()
+        if run_long_tests()
+            test_something_slow()
+        end
+    end
+end
+```
+
+Test files that do not already `include("utilities.jl")` will need to add it. A whole test file can be gated the same way from `test/runtests.jl`:
+
+```julia
+if run_long_tests()
+    Test.@testset verbose = true "Slow tests" begin
+        include("test_something_slow.jl")
+    end
+end
+```
+
+As a rule of thumb, a test belongs in the long suite if it solves a full case, downloads inputs, or otherwise takes more than a few seconds.

--- a/docs/src/References/5_utilities.md
+++ b/docs/src/References/5_utilities.md
@@ -165,6 +165,16 @@ MacroEnergy.reconstruct_benders_variable
 MacroEnergy.reconstruct_timeseries
 ```
 
+## `release_model_references!`
+```@docs
+MacroEnergy.release_model_references!
+```
+
+## `release_model!`
+```@docs
+MacroEnergy.release_model!
+```
+
 ## `reshape_wide`
 ```@docs
 MacroEnergy.reshape_wide

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -32,7 +32,9 @@ and this project follows Julia package versioning through `Project.toml` release
 
 ### Fixed
 
+- Myopic runs with `MyopicSettings.ReturnModels = false` now actually free each period's model. Each period's references are now released once its results have been written, and the model is emptied. Results are unchanged; scalar capacities remain readable on the returned `Case` as `Float64`.
 - Fix wacc default preventing fallback to DiscountRate. Omitted `wacc` was silently treated as `0.0` instead of falling back to the case-level `DiscountRate`.
+- Duplicate asset IDs within a system are now rejected during system generation, preventing ambiguous myopic capacity carry-over and late wide-output failures.
 
 ### Documentation
 

--- a/src/MacroEnergy.jl
+++ b/src/MacroEnergy.jl
@@ -184,6 +184,7 @@ include("model/scaling.jl")
 include("model/myopic.jl")
 include_all_in_folder("model/constraints")
 include_all_in_folder("model/benders")
+include("model/release_model.jl")
 include("model/solver.jl")
 
 include("utilities/postprocessing.jl")

--- a/src/model/release_model.jl
+++ b/src/model/release_model.jl
@@ -1,0 +1,185 @@
+####### Releasing the JuMP references held by a solved System #######
+#
+# Scalar planning quantities (capacity, new/retired capacity and units) are replaced
+# by their solution values, so the System still reports what was built in that
+# period; the time-indexed variables and the constraint references are reset to their 
+# empty defaults.
+#
+# Values are stored in the same (scaled) units
+
+"""
+    release_model_references!(x)
+
+Recursively strip the JuMP references stored in `x`, where `x` is a `System`,
+`Location`, asset, edge, vertex or constraint.
+
+Scalar capacity fields are replaced by their solution values; time-indexed
+variables, balance expressions and constraint references are reset to empty.
+
+This must only be called once the model has been solved and its results written:
+it calls `value` on the capacity variables, and any JuMP reference obtained from
+the System beforehand is stale afterwards.
+
+See also [`release_model!`](@ref).
+"""
+function release_model_references! end
+
+# Solution value of a scalar planning quantity. `value` of a constant `AffExpr`
+# does not touch the model, so components without capacity variables are fine.
+solution_value(x::Union{VariableRef,AffExpr}) = value(x)
+solution_value(x::Real) = x
+solution_value(::Missing) = missing
+
+function release_model_references!(system::System)
+    for asset in system.assets
+        release_model_references!(asset)
+    end
+    for location in system.locations
+        release_model_references!(location)
+    end
+    for constraint in system.constraints
+        release_model_references!(constraint)
+    end
+    return nothing
+end
+
+function release_model_references!(a::AbstractAsset)
+    for t in fieldnames(typeof(a))
+        release_model_references!(getfield(a, t))
+    end
+    return nothing
+end
+
+function release_model_references!(location::Location)
+    for node in values(location.nodes)
+        release_model_references!(node)
+    end
+    for constraint in location.constraints
+        release_model_references!(constraint)
+    end
+    return nothing
+end
+
+function release_model_references!(x::Union{AbstractArray,AbstractDict,Tuple})
+    for element in values(x)
+        release_model_references!(element)
+    end
+    return nothing
+end
+
+function release_model_references!(e::AbstractEdge)
+    e.capacity = solution_value(capacity(e))
+    e.existing_capacity = solution_value(existing_capacity(e))
+    e.new_capacity = solution_value(new_capacity(e))
+    e.retired_capacity = solution_value(retired_capacity(e))
+    e.retrofitted_capacity = solution_value(retrofitted_capacity(e))
+    e.new_units = solution_value(new_units(e))
+    e.retired_units = solution_value(retired_units(e))
+    e.retrofitted_units = solution_value(retrofitted_units(e))
+    release_capacity_tracks!(e)
+    e.flow = Vector{VariableRef}()
+    for constraint in e.constraints
+        release_model_references!(constraint)
+    end
+    return nothing
+end
+
+function release_model_references!(e::EdgeWithUC)
+    invoke(release_model_references!, Tuple{AbstractEdge}, e)
+    e.ucommit = Vector{VariableRef}()
+    e.ushut = Vector{VariableRef}()
+    e.ustart = Vector{VariableRef}()
+    return nothing
+end
+
+function release_model_references!(g::AbstractStorage)
+    g.capacity = solution_value(capacity(g))
+    g.existing_capacity = solution_value(existing_capacity(g))
+    g.new_capacity = solution_value(new_capacity(g))
+    g.retired_capacity = solution_value(retired_capacity(g))
+    release_capacity_tracks!(g)
+    g.new_units = missing
+    g.retired_units = missing
+    g.storage_level = Vector{VariableRef}()
+    release_vertex_references!(g)
+    return nothing
+end
+
+function release_model_references!(g::LongDurationStorage)
+    invoke(release_model_references!, Tuple{AbstractStorage}, g)
+    g.storage_initial = Vector{VariableRef}()
+    g.storage_change = Vector{VariableRef}()
+    return nothing
+end
+
+function release_model_references!(n::Node)
+    n.non_served_demand = Matrix{VariableRef}(undef, 0, 0)
+    n.supply_flow = Matrix{VariableRef}(undef, 0, 0)
+    empty!(n.policy_budgeting_vars)
+    empty!(n.policy_budgeting_constraints)
+    empty!(n.policy_slack_vars)
+    release_vertex_references!(n)
+    return nothing
+end
+
+release_model_references!(g::Transformation) = release_vertex_references!(g)
+
+function release_model_references!(ct::AbstractTypeConstraint)
+    hasproperty(ct, :constraint_ref) && (ct.constraint_ref = missing)
+    return nothing
+end
+
+# `operation_expr` holds the balance expressions, which are `AffExpr`s over the model's variables
+function release_vertex_references!(v::AbstractVertex)
+    empty!(v.operation_expr)
+    for constraint in v.constraints
+        release_model_references!(constraint)
+    end
+    return nothing
+end
+
+function release_capacity_track!(track::AbstractDict)
+    for (period, tracked) in track
+        track[period] = solution_value(tracked)
+    end
+    return nothing
+end
+
+function release_capacity_tracks!(y::Union{AbstractEdge,AbstractStorage})
+    release_capacity_track!(y.new_capacity_track)
+    release_capacity_track!(y.retired_capacity_track)
+    isa(y, AbstractEdge) && release_capacity_track!(y.retrofitted_capacity_track)
+    return nothing
+end
+
+"""
+    release_model!(system::System, model)
+
+Release the model built for `system` once its results have been written.
+
+Strips the JuMP references that `system` holds (see
+[`release_model_references!`](@ref)) and then calls `empty!` on `model`, so that
+the solver's copy of the problem is released immediately.
+
+`model` is unusable afterwards; only call this when the model is not being
+returned to the caller (`MyopicSettings.ReturnModels == false`).
+"""
+function release_model!(system::System, model::Model)
+    release_model_references!(system)
+    empty!(model)
+    return nothing
+end
+
+function release_model!(system::System, model::BendersModel)
+    release_model_references!(system)
+    empty!(model.planning_problem)
+    # Distributed subproblems are left to the DArray's finalizer.
+    if model.subproblems isa Vector{Dict{Any,Any}}
+        for subproblem in model.subproblems
+            haskey(subproblem, :system_local) &&
+                release_model_references!(subproblem[:system_local])
+            haskey(subproblem, :model) && empty!(subproblem[:model])
+        end
+    end
+    return nothing
+end

--- a/src/model/release_model.jl
+++ b/src/model/release_model.jl
@@ -37,9 +37,6 @@ function release_model_references!(system::System)
     for location in system.locations
         release_model_references!(location)
     end
-    for constraint in system.constraints
-        release_model_references!(constraint)
-    end
     return nothing
 end
 
@@ -53,9 +50,6 @@ end
 function release_model_references!(location::Location)
     for node in values(location.nodes)
         release_model_references!(node)
-    end
-    for constraint in location.constraints
-        release_model_references!(constraint)
     end
     return nothing
 end

--- a/src/model/solver.jl
+++ b/src/model/solver.jl
@@ -72,7 +72,13 @@ function solve_case(case::Case, opt::O, ::Myopic) where O <: Union{Optimizer, Di
 
         push!(capacity_summaries, write_outputs(output_path, case, model, system, period_idx))
 
-        return_results ? (stored[period_idx] = model) : (model = nothing; GC.gc())
+        if return_results
+            stored[period_idx] = model
+        else
+            release_model!(system, model)
+            model = nothing
+            GC.gc()
+        end
     end
 
     length(capacity_summaries) > 1 && write_capacity_summary(output_path, capacity_summaries, get_output_layout(periods[1], :CapacitySummary))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,9 @@ import Test
 using Logging
 using MacroEnergy
 
+include("utilities.jl")
+
+@info "Running the \"$TEST_SUITE\" test suite"
 
 test_logger = ConsoleLogger(stderr, Logging.Warn)
 

--- a/test/test_myopic.jl
+++ b/test/test_myopic.jl
@@ -64,8 +64,6 @@ function assert_constraint_references_released(constraints)
 end
 
 function assert_model_references_released!(system::System)
-    assert_constraint_references_released(system.constraints)
-
     for asset in system.assets
         for field in fieldnames(typeof(asset))
             component = getfield(asset, field)
@@ -123,7 +121,6 @@ function assert_model_references_released!(system::System)
             @test isempty(location.operation_expr)
             assert_constraint_references_released(location.constraints)
         elseif location isa Location
-            assert_constraint_references_released(location.constraints)
             for node in values(location.nodes)
                 @test isempty(node.non_served_demand)
                 @test isempty(node.supply_flow)

--- a/test/test_myopic.jl
+++ b/test/test_myopic.jl
@@ -12,7 +12,131 @@ import MacroEnergy:
     MyopicResults,
     Case,
     System,
-    default_myopic_settings
+    default_myopic_settings,
+    AbstractEdge,
+    EdgeWithUC,
+    AbstractStorage,
+    LongDurationStorage,
+    Transformation,
+    Node,
+    Location,
+    solve_case,
+    create_optimizer,
+    get_edges,
+    get_storages
+
+const MYOPIC_TEST_INPUTS = joinpath(@__DIR__, "test_inputs")
+include("utilities.jl")
+
+function write_two_period_myopic_case!(case_path::AbstractString)
+    system_data_path = joinpath(case_path, "system_data.json")
+    system_data = JSON3.read(read(system_data_path, String), Dict{String,Any})
+    case_data = Dict(
+        "case" => [system_data, deepcopy(system_data)],
+        "settings" => Dict("path" => "settings/case_settings.json"),
+    )
+    write(system_data_path, JSON3.write(case_data))
+
+    case_settings = Dict(
+        "SolutionAlgorithm" => "Monolithic",
+        "ExpansionHorizon" => "Myopic",
+        "PeriodLengths" => [1, 1],
+        "ParameterScaling" => true,
+        "WriteFullTimeseries" => false,
+        "MyopicSettings" => Dict(
+            "ReturnModels" => false,
+            "WriteModelLP" => false,
+        ),
+    )
+    write(
+        joinpath(case_path, "settings", "case_settings.json"),
+        JSON3.write(case_settings),
+    )
+    return nothing
+end
+
+function assert_constraint_references_released(constraints)
+    for constraint in constraints
+        hasproperty(constraint, :constraint_ref) || continue
+        @test ismissing(getproperty(constraint, :constraint_ref))
+    end
+    return nothing
+end
+
+function assert_model_references_released!(system::System)
+    assert_constraint_references_released(system.constraints)
+
+    for asset in system.assets
+        for field in fieldnames(typeof(asset))
+            component = getfield(asset, field)
+            if component isa AbstractEdge
+                @test component.capacity isa Real
+                @test component.existing_capacity isa Real
+                @test component.new_capacity isa Real
+                @test component.retired_capacity isa Real
+                @test component.new_units isa Real
+                @test component.retired_units isa Real
+                @test component.retrofitted_units isa Real
+                @test isempty(component.flow)
+                @test isempty(component.retrofitted_capacity.terms)
+                @test all(isempty(track.terms) for track in values(component.new_capacity_track))
+                @test all(isempty(track.terms) for track in values(component.retired_capacity_track))
+                @test all(isempty(track.terms) for track in values(component.retrofitted_capacity_track))
+                assert_constraint_references_released(component.constraints)
+
+                if component isa EdgeWithUC
+                    @test isempty(component.ucommit)
+                    @test isempty(component.ushut)
+                    @test isempty(component.ustart)
+                end
+            elseif component isa AbstractStorage
+                @test component.capacity isa Real
+                @test component.existing_capacity isa Real
+                @test component.new_capacity isa Real
+                @test component.retired_capacity isa Real
+                @test ismissing(component.new_units)
+                @test ismissing(component.retired_units)
+                @test isempty(component.storage_level)
+                @test all(isempty(track.terms) for track in values(component.new_capacity_track))
+                @test all(isempty(track.terms) for track in values(component.retired_capacity_track))
+                @test isempty(component.operation_expr)
+                assert_constraint_references_released(component.constraints)
+
+                if component isa LongDurationStorage
+                    @test isempty(component.storage_initial)
+                    @test isempty(component.storage_change)
+                end
+            elseif component isa Transformation
+                @test isempty(component.operation_expr)
+                assert_constraint_references_released(component.constraints)
+            end
+        end
+    end
+
+    for location in system.locations
+        if location isa Node
+            @test isempty(location.non_served_demand)
+            @test isempty(location.supply_flow)
+            @test isempty(location.policy_budgeting_vars)
+            @test isempty(location.policy_budgeting_constraints)
+            @test isempty(location.policy_slack_vars)
+            @test isempty(location.operation_expr)
+            assert_constraint_references_released(location.constraints)
+        elseif location isa Location
+            assert_constraint_references_released(location.constraints)
+            for node in values(location.nodes)
+                @test isempty(node.non_served_demand)
+                @test isempty(node.supply_flow)
+                @test isempty(node.policy_budgeting_vars)
+                @test isempty(node.policy_budgeting_constraints)
+                @test isempty(node.policy_slack_vars)
+                @test isempty(node.operation_expr)
+                assert_constraint_references_released(node.constraints)
+            end
+        end
+    end
+    return nothing
+end
 
 """
 Test MyopicResults structure and basic functionality
@@ -199,7 +323,56 @@ function test_myopic_memory_optimization()
     end
 end
 
-"""
+function test_myopic_model_release()
+    @testset "Myopic model release" begin
+        temporary_root = abspath(mktempdir("."))
+        case_path = joinpath(temporary_root, "case")
+        try
+            cp(MYOPIC_TEST_INPUTS, case_path)
+            write_two_period_myopic_case!(case_path)
+
+            case = load_case(case_path)
+            _, results = solve_case(
+                case,
+                create_optimizer(
+                    HiGHS.Optimizer,
+                    nothing,
+                    (
+                        "solver" => "ipm",
+                        "run_crossover" => "off",
+                        "ipm_optimality_tolerance" => 1e-3,
+                        "log_to_console" => false,
+                    )
+                ),
+            )
+
+            @test results isa MyopicResults
+            @test isnothing(results.results)
+            @test length(case.systems) == 2
+
+            first_period, second_period = case.systems
+            first_components = Dict(
+                component.id => component for component in vcat(
+                    get_edges(first_period),
+                    get_storages(first_period),
+                )
+            )
+            for component in vcat(
+                get_edges(second_period),
+                get_storages(second_period),
+            )
+                @test component.existing_capacity ≈ first_components[component.id].capacity
+            end
+
+            assert_model_references_released!(first_period)
+            assert_model_references_released!(second_period)
+        finally
+            rm(temporary_root; recursive=true, force=true)
+        end
+    end
+end
+
+""""
 Run all myopic tests
 """
 function run_myopic_tests()
@@ -209,6 +382,9 @@ function run_myopic_tests()
         test_myopic_case_integration()
         test_myopic_error_handling()
         test_myopic_memory_optimization()
+        if run_long_tests()
+            @warn_error_logger test_myopic_model_release()
+        end
     end
 end
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,6 +1,22 @@
 using Logging
 
 
+# Test suite selection. "short" (the default) skips the tests that solve full
+# cases; "long" runs everything. Select the suite with either:
+#   julia> Pkg.test("MacroEnergy"; test_args=["long"])
+#   $ MACRO_TEST_SUITE=long julia --project=. test/runtests.jl
+function macro_test_suite()
+    for arg in ARGS
+        suite = lowercase(lstrip(arg, '-'))
+        suite in ("short", "long") && return suite
+    end
+    return lowercase(get(ENV, "MACRO_TEST_SUITE", "short"))
+end
+
+const TEST_SUITE = macro_test_suite()
+
+run_long_tests() = TEST_SUITE == "long"
+
 macro log_with_level(log_level, block)
     quote
         result = redirect_stdout(devnull) do


### PR DESCRIPTION
## Description
This PR fixes the release of JuMP models in myopic runs when `ReturnModels: false`.

The current implementation only frees the local model binding not the actual JuMP model, and so peak memory grows with the number of periods (as verified with few large cases). The reason for that is that the `System` object holds strong references to the `Model` (JuMP variable and constraint) and each of these keeps the whole `Model` alive. 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.