### PR TITLE
Local benchmarking tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ output.log
 
 *.log
 /examples
+/benchmark/results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project follows Julia package versioning through `Project.toml` release
 - Added capacity_summary.csv for multi-period cases, combining per-period capacity outputs into a single long- or wide-format file.
 - Added optional StartYear input in case_settings.json to label periods by calendar year.
 - Added `capex.csv` output file to report per-component asset capital costs.
+- Added repository-local benchmarking tools to compare case loading, case generation, and model generation between `upstream/main` and the current worktree using reproducible example inputs.
 
 ### Changed
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,23 @@
+# Local benchmarks
+
+Run:
+
+```sh
+julia --project=. benchmark/run.jl
+```
+
+The wrapper benchmarks every name in `BENCHMARK_EXAMPLE_NAMES` (currently
+`multisector_3zone`). It downloads version `0.2.0` once, creates a temporary worktree
+from `upstream/main`, and runs the same BenchmarkTools worker under that public baseline
+and the current dirty project. Workers use private input copies and prepare runtime user
+additions. No solver or external benchmark tool is required.
+
+The ignored `benchmark/results/results.json` contains both revisions for every example,
+per-stage time, allocations, and allocated bytes, plus a geometric-mean speedup and
+average allocation/memory improvements. Temporary per-worker result files are removed.
+
+To compare with your local `main` instead, run:
+
+```sh
+julia --project=. -e 'include("benchmark/benchmark_helpers.jl"); benchmark_examples(main_revision="main")'
+```

--- a/benchmark/benchmark_helpers.jl
+++ b/benchmark/benchmark_helpers.jl
@@ -1,0 +1,202 @@
+using JSON3
+using MacroEnergy
+using Printf
+using Statistics
+
+const BENCHMARK_EXAMPLE_NAMES = ["multisector_3zone"]
+const BENCHMARK_EXAMPLE_VERSION = "0.2.0"
+const BENCHMARK_STAGES = ("load", "generate_case", "generate_model")
+
+benchmark_repo_root() = abspath(joinpath(@__DIR__, ".."))
+benchmark_example_dir(repo_root::AbstractString = benchmark_repo_root()) =
+    joinpath(repo_root, "examples")
+benchmark_example_path(examples_dir::AbstractString, name::AbstractString) =
+    joinpath(examples_dir, name)
+benchmark_example_marker(examples_dir::AbstractString, name::AbstractString) =
+    joinpath(examples_dir, ".$(name).version")
+benchmark_results_path(repo_root::AbstractString = benchmark_repo_root()) =
+    joinpath(repo_root, "benchmark", "results", "results.json")
+
+function benchmark_example_state(
+    examples_dir::AbstractString,
+    name::AbstractString;
+    version::AbstractString,
+)
+    case_path = benchmark_example_path(examples_dir, name)
+    marker_path = benchmark_example_marker(examples_dir, name)
+    marker_version = isfile(marker_path) ? strip(read(marker_path, String)) : nothing
+
+    if isdir(case_path) && marker_version == version
+        return :ready
+    elseif !isdir(case_path) && isnothing(marker_version)
+        return :missing
+    end
+    return :mismatch
+end
+
+function refresh_benchmark_example!(examples_dir::AbstractString, name::AbstractString)
+    rm(benchmark_example_path(examples_dir, name); recursive = true, force = true)
+    rm(benchmark_example_marker(examples_dir, name); force = true)
+    return nothing
+end
+
+"""
+    ensure_benchmark_example!(examples_dir, name;
+                              version = BENCHMARK_EXAMPLE_VERSION,
+                              refresh = false, downloader = download_example)
+
+Ensure that `examples_dir` contains `name` at the requested version. The marker prevents
+an existing download from silently being reused with a different benchmark input.
+"""
+function ensure_benchmark_example!(
+    examples_dir::AbstractString,
+    name::AbstractString;
+    version::AbstractString = BENCHMARK_EXAMPLE_VERSION,
+    refresh::Bool = false,
+    downloader::Function = download_example,
+)
+    state = benchmark_example_state(examples_dir, name; version)
+    case_path = benchmark_example_path(examples_dir, name)
+
+    if state == :ready
+        return abspath(case_path)
+    elseif state == :mismatch && !refresh
+        throw(
+            ArgumentError(
+                "Benchmark example at $(abspath(case_path)) does not match version $version. " *
+                "Rerun with refresh=true to replace it.",
+            ),
+        )
+    end
+
+    refresh && refresh_benchmark_example!(examples_dir, name)
+    mkpath(examples_dir)
+    cd(dirname(abspath(examples_dir))) do
+        downloader(name, basename(examples_dir); version)
+    end
+
+    isdir(case_path) || error("Expected benchmark example at $(abspath(case_path)) after download")
+    write(benchmark_example_marker(examples_dir, name), version * "\n")
+    return abspath(case_path)
+end
+
+function worker_command(
+    project_dir::AbstractString,
+    case_path::AbstractString,
+    result_path::AbstractString,
+    label::AbstractString,
+)
+    return `$(Base.julia_cmd()) --project=$(abspath(project_dir)) --startup-file=no $(joinpath(@__DIR__, "worker.jl")) $(abspath(case_path)) $(abspath(result_path)) $label`
+end
+
+instantiate_project(project_dir::AbstractString) = run(`$(Base.julia_cmd()) --project=$(abspath(project_dir)) --startup-file=no -e 'using Pkg; Pkg.instantiate()'`)
+run_worker(command::Cmd) = run(command)
+
+function with_main_worktree(f::Function, main_revision::AbstractString)
+    worktree = mktempdir()
+    try
+        run(`git -C $(benchmark_repo_root()) worktree add --detach $worktree $main_revision`)
+        return f(worktree)
+    finally
+        run(`git -C $(benchmark_repo_root()) worktree remove --force $worktree`)
+    end
+end
+
+function run_worker_result(
+    project_dir::AbstractString,
+    case_path::AbstractString,
+    label::AbstractString,
+    worker_runner::Function,
+)
+    result_path, io = mktemp()
+    close(io)
+    try
+        worker_runner(worker_command(project_dir, case_path, result_path, label))
+        return JSON3.read(read(result_path, String))
+    finally
+        rm(result_path; force = true)
+    end
+end
+
+function percentage_improvement(main_value::Real, dirty_value::Real)
+    iszero(main_value) && return 0.0
+    return 100 * (main_value - dirty_value) / main_value
+end
+
+function comparison_summary(benchmark_results)
+    speedups = Float64[]
+    allocation_improvements = Float64[]
+    memory_improvements = Float64[]
+
+    for result in values(benchmark_results), stage in BENCHMARK_STAGES
+        main = result[:main][:benchmarks][Symbol(stage)]
+        dirty = result[:dirty][:benchmarks][Symbol(stage)]
+        main_time = main[:median_seconds]
+        dirty_time = dirty[:median_seconds]
+        main_time > 0 && dirty_time > 0 && push!(speedups, main_time / dirty_time)
+        push!(allocation_improvements, percentage_improvement(main[:allocations], dirty[:allocations]))
+        push!(memory_improvements, percentage_improvement(main[:memory_bytes], dirty[:memory_bytes]))
+    end
+
+    return Dict(
+        :geometric_mean_speedup => isempty(speedups) ? 1.0 : exp(mean(log, speedups)),
+        :average_allocation_improvement => isempty(allocation_improvements) ? 0.0 : mean(allocation_improvements),
+        :average_memory_improvement => isempty(memory_improvements) ? 0.0 : mean(memory_improvements),
+    )
+end
+
+function print_results(benchmark_results, summary)
+    println("\nBenchmark comparison (main / dirty):")
+    @printf("%-20s %-16s %10s %10s %9s %14s %14s %14s %14s\n",
+        "example", "stage", "main (s)", "dirty (s)", "speedup", "main allocs", "dirty allocs", "main bytes", "dirty bytes")
+    for (name, result) in sort(collect(benchmark_results); by = first), stage in BENCHMARK_STAGES
+        main = result[:main][:benchmarks][Symbol(stage)]
+        dirty = result[:dirty][:benchmarks][Symbol(stage)]
+        speedup = iszero(dirty[:median_seconds]) ? Inf : main[:median_seconds] / dirty[:median_seconds]
+        @printf("%-20s %-16s %10.3f %10.3f %8.2fx %14d %14d %14d %14d\n",
+            name, stage, main[:median_seconds], dirty[:median_seconds], speedup,
+            main[:allocations], dirty[:allocations], main[:memory_bytes], dirty[:memory_bytes])
+    end
+    @printf("\nGeometric-mean speedup: %.2fx; average allocation improvement: %.1f%%; average memory improvement: %.1f%%\n",
+        summary[:geometric_mean_speedup], summary[:average_allocation_improvement], summary[:average_memory_improvement])
+    return nothing
+end
+
+"""
+    benchmark_examples(; main_revision = "upstream/main", examples = BENCHMARK_EXAMPLE_NAMES,
+                         examples_dir = benchmark_example_dir(), refresh = false,
+                         results_path = benchmark_results_path())
+
+Compare each requested example under the public `upstream/main` baseline and this dirty
+worktree. A single JSON file contains both revisions and an aggregate summary.
+"""
+function benchmark_examples(
+    ;
+    main_revision::AbstractString = "upstream/main",
+    examples::AbstractVector{<:AbstractString} = BENCHMARK_EXAMPLE_NAMES,
+    examples_dir::AbstractString = benchmark_example_dir(),
+    refresh::Bool = false,
+    results_path::AbstractString = benchmark_results_path(),
+    worker_runner::Function = run_worker,
+)
+    case_paths = Dict(name => ensure_benchmark_example!(examples_dir, name; refresh) for name in examples)
+    mkpath(dirname(results_path))
+    instantiate_project(benchmark_repo_root())
+
+    benchmark_results = with_main_worktree(main_revision) do main_worktree
+        instantiate_project(main_worktree)
+        Dict(
+            name => Dict(
+                :main => run_worker_result(main_worktree, case_path, "main", worker_runner),
+                :dirty => run_worker_result(benchmark_repo_root(), case_path, "dirty", worker_runner),
+            ) for (name, case_path) in case_paths
+        )
+    end
+    summary = comparison_summary(benchmark_results)
+    results = Dict(:examples => benchmark_results, :summary => summary)
+    open(results_path, "w") do io
+        JSON3.write(io, results)
+    end
+    print_results(benchmark_results, summary)
+    return results
+end

--- a/benchmark/run.jl
+++ b/benchmark/run.jl
@@ -1,0 +1,4 @@
+include("benchmark_helpers.jl")
+
+examples = ["multisector_3zone"]
+benchmark_examples(; examples = examples)

--- a/benchmark/worker.jl
+++ b/benchmark/worker.jl
@@ -1,0 +1,76 @@
+using BenchmarkTools
+using HiGHS
+using JSON3
+using Logging
+using MacroEnergy
+
+function bootstrap(case_path::AbstractString)
+    MacroEnergy.setup_user_additions(case_path)
+    data = MacroEnergy.load_case_data(joinpath(case_path, "system_data.json"); lazy_load = true)
+    MacroEnergy.generate_case(joinpath(case_path, "system_data.json"), data)
+    return nothing
+end
+
+if first(ARGS) == "--bootstrap"
+    length(ARGS) == 2 || error("Usage: worker.jl --bootstrap CASE_PATH")
+    bootstrap(abspath(ARGS[2]))
+    exit()
+end
+
+length(ARGS) == 3 || error("Usage: worker.jl CASE_PATH RESULT_PATH LABEL")
+const CASE_PATH, RESULT_PATH, LABEL = abspath(ARGS[1]), abspath(ARGS[2]), ARGS[3]
+
+function scratch_case(source::AbstractString)
+    root = mktempdir()
+    path = joinpath(root, basename(source))
+    cp(source, path; force = true)
+    return path
+end
+
+function prepare_case!(path::AbstractString)
+    command = `$(Base.julia_cmd()) --project=$(dirname(Base.active_project())) --startup-file=no $(@__FILE__) --bootstrap $path`
+    run(command)
+    isfile(MacroEnergy.user_additions_commodities_path(path)) || error("Bootstrap did not create user additions")
+    MacroEnergy.load_user_additions(path)
+    MacroEnergy.refresh_user_type_registries!()
+    return nothing
+end
+
+load_stage(path::AbstractString) = with_logger(NullLogger()) do
+    MacroEnergy.load_case_data(joinpath(path, "system_data.json"); lazy_load = true)
+end
+
+generate_case_stage(path::AbstractString, data::Dict{Symbol,Any}) = with_logger(NullLogger()) do
+    MacroEnergy.generate_case(joinpath(path, "system_data.json"), data)
+end
+
+function generate_model_stage(case::MacroEnergy.Case)
+    optimizer = MacroEnergy.create_optimizer(HiGHS.Optimizer, nothing, ("solver" => "ipm", "run_crossover" => "off", "ipm_optimality_tolerance" => 1e-3))
+    return with_logger(NullLogger()) do
+        MacroEnergy.generate_model(case, optimizer, MacroEnergy.solution_algorithm(case))
+    end
+end
+
+function summary(trial::BenchmarkTools.Trial)
+    value = median(trial)
+    return Dict(:median_seconds => value.time / 1e9, :memory_bytes => value.memory, :allocations => value.allocs)
+end
+
+function run_benchmarks(path::AbstractString)
+    prepare_case!(path)
+    generate_case_stage(path, load_stage(path)) # warm-up; excluded from timing
+    load_trial = @benchmark load_stage($path) evals = 1 samples = 5
+    case_trial = @benchmark generate_case_stage($path, data) setup = (data = load_stage($path)) evals = 1 samples = 5
+    model_trial = @benchmark generate_model_stage(case) setup = begin
+        data = load_stage($path)
+        case = generate_case_stage($path, data)
+    end evals = 1 samples = 5
+    return Dict(:load => summary(load_trial), :generate_case => summary(case_trial), :generate_model => summary(model_trial))
+end
+
+isdir(CASE_PATH) || error("Case directory does not exist: $CASE_PATH")
+results = Dict(:label => LABEL, :benchmarks => run_benchmarks(scratch_case(CASE_PATH)))
+mkpath(dirname(RESULT_PATH))
+open(RESULT_PATH, "w") do io
+    JSON3.write(io, results)
+end

--- a/benchmark/worker.jl
+++ b/benchmark/worker.jl
@@ -5,9 +5,7 @@ using Logging
 using MacroEnergy
 
 function bootstrap(case_path::AbstractString)
-    MacroEnergy.setup_user_additions(case_path)
-    data = MacroEnergy.load_case_data(joinpath(case_path, "system_data.json"); lazy_load = true)
-    MacroEnergy.generate_case(joinpath(case_path, "system_data.json"), data)
+    MacroEnergy.materialize_user_commodities!(case_path)
     return nothing
 end
 

--- a/docs/src/References/2_reading_input.md
+++ b/docs/src/References/2_reading_input.md
@@ -49,6 +49,11 @@ MacroEnergy.load_system
 MacroEnergy.load_system_data
 ```
 
+## `materialize_user_commodities!`
+```@docs
+MacroEnergy.materialize_user_commodities!
+```
+
 ## `prep_system_data`
 ```@docs
 MacroEnergy.prep_system_data

--- a/src/utilities/user_additions.jl
+++ b/src/utilities/user_additions.jl
@@ -144,6 +144,51 @@ function setup_user_additions(case_path::AbstractString=pwd())
     return nothing
 end
 
+"""
+    materialize_user_commodities!(case_path)
+    materialize_user_commodities!(case_path, case_data)
+    materialize_user_commodities!(case_path, systems_data)
+
+Materialize the user commodity definitions required by a case without generating its
+locations, time data, nodes, or assets. This is useful when a fresh Julia process must
+write `user_additions/usercommodities.jl` before another process loads the case.
+
+The overloads deliberately separate loading a case from processing its periods: callers
+that already have `case_data` avoid another read, while the vector method applies the
+same commodity preparation to every system period.
+"""
+function materialize_user_commodities!(case_path::AbstractString)
+    data_path = joinpath(case_path, "system_data.json")
+    return materialize_user_commodities!(
+        case_path,
+        load_case_data(data_path; lazy_load=true),
+    )
+end
+
+function materialize_user_commodities!(
+    case_path::AbstractString,
+    case_data::AbstractDict{Symbol,Any},
+)
+    setup_user_additions(case_path)
+    return materialize_user_commodities!(case_path, case_data[:case])
+end
+
+function materialize_user_commodities!(
+    case_path::AbstractString,
+    systems_data::AbstractVector{<:AbstractDict{Symbol,Any}},
+)
+    for system_data in systems_data
+        settings = configure_settings(system_data[:settings], case_path)
+        load_commodities(
+            system_data[:commodities],
+            case_path;
+            write_subcommodities=settings.WriteSubcommodities,
+            allow_implicit_top_level_commodities=settings.AllowImplicitTopLevelCommodities,
+        )
+    end
+    return nothing
+end
+
 function read_unique_nonempty_lines(file_path::AbstractString)
     lines = String[]
     seen = Set{String}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,5 +88,9 @@ with_logger(test_logger) do
         include("test_accessor_allocation.jl")
         include("test_node_supply_accessors.jl")
     end
+
+    Test.@testset "Benchmark tooling" begin
+        include("test_benchmark_runner.jl")
+    end
     return nothing
 end

--- a/test/test_benchmark_runner.jl
+++ b/test/test_benchmark_runner.jl
@@ -1,0 +1,45 @@
+module TestBenchmarkRunner
+using Test
+using MacroEnergy
+include(joinpath(@__DIR__, "..", "benchmark", "benchmark_helpers.jl"))
+
+function mock_downloader(counter)
+    return function (name, target_dir; version)
+        counter[] += 1
+        path = joinpath(target_dir, name)
+        mkpath(path)
+        write(joinpath(path, "system_data.json"), "{}")
+    end
+end
+
+@testset "Benchmark runner" begin
+    mktempdir() do dir
+        examples = joinpath(dir, "examples")
+        counter = Ref(0)
+        downloader = mock_downloader(counter)
+        name = only(BENCHMARK_EXAMPLE_NAMES)
+        path = ensure_benchmark_example!(examples, name; downloader)
+        @test isdir(path)
+        @test counter[] == 1
+        @test ensure_benchmark_example!(examples, name; downloader) == path
+        write(benchmark_example_marker(examples, name), "wrong\n")
+        @test_throws ArgumentError ensure_benchmark_example!(examples, name; downloader)
+        @test ensure_benchmark_example!(examples, name; refresh = true, downloader) == path
+        @test counter[] == 2
+    end
+    command = worker_command("/tmp/main", "/tmp/case", "/tmp/results/main.json", "main")
+    @test occursin("--project=/tmp/main", string(command))
+    @test occursin("worker.jl", string(command))
+    @test applicable(with_main_worktree, () -> nothing, "main")
+
+    benchmark = Dict(
+        :main => Dict(:benchmarks => Dict(stage => Dict(:median_seconds => 2.0, :allocations => 4, :memory_bytes => 8) for stage in Symbol.(BENCHMARK_STAGES))),
+        :dirty => Dict(:benchmarks => Dict(stage => Dict(:median_seconds => 1.0, :allocations => 2, :memory_bytes => 4) for stage in Symbol.(BENCHMARK_STAGES))),
+    )
+    summary = comparison_summary(Dict("example" => benchmark))
+    @test summary[:geometric_mean_speedup] == 2.0
+    @test summary[:average_allocation_improvement] == 50.0
+    @test summary[:average_memory_improvement] == 50.0
+    @test percentage_improvement(0, 0) == 0.0
+end
+end

--- a/test/test_benchmark_runner.jl
+++ b/test/test_benchmark_runner.jl
@@ -28,7 +28,8 @@ end
         @test counter[] == 2
     end
     command = worker_command("/tmp/main", "/tmp/case", "/tmp/results/main.json", "main")
-    @test occursin("--project=/tmp/main", string(command))
+    project_argument = only(filter(arg -> startswith(arg, "--project="), command.exec))
+    @test normpath(project_argument[length("--project=")+1:end]) == normpath("/tmp/main")
     @test occursin("worker.jl", string(command))
     @test applicable(with_main_worktree, () -> nothing, "main")
 

--- a/test/test_user_additions.jl
+++ b/test/test_user_additions.jl
@@ -19,6 +19,7 @@ import MacroEnergy:
     Commodity,
     register_commodity_types!,
     setup_user_additions,
+    materialize_user_commodities!,
     load_user_additions,
     user_additions_path,
     user_additions_assets_dir,
@@ -235,6 +236,36 @@ function test_subcommodities_dependency_write_order()
 end
 
 """
+Verify commodity materialization writes definitions without constructing a full case.
+
+The two-period input exercises the vector overload while keeping each period's
+commodity declarations independently resolvable.
+"""
+function test_materialize_user_commodities()
+    case_path = mktempdir()
+    top_level = unique_test_symbol("TestMaterializedFuel")
+    child = unique_test_symbol("TestMaterializedFuelChild")
+    settings = Dict{Symbol,Any}(
+        :WriteSubcommodities => true,
+        :AllowImplicitTopLevelCommodities => true,
+    )
+    case_data = Dict{Symbol,Any}(
+        :case => [
+            Dict{Symbol,Any}(:settings => copy(settings), :commodities => Any[String(top_level)]),
+            Dict{Symbol,Any}(:settings => copy(settings), :commodities => Any[
+                Dict{Symbol,Any}(:name => String(child), :acts_like => "LiquidFuels"),
+            ]),
+        ],
+    )
+
+    @test materialize_user_commodities!(case_path, case_data) === nothing
+    @test readlines(user_additions_commodities_path(case_path)) == [
+        "abstract type $(top_level) <: MacroEnergy.Commodity end",
+        "abstract type $(child) <: MacroEnergy.LiquidFuels end",
+    ]
+end
+
+"""
 Verify user-defined assets are loaded into MacroEnergy scope.
 
 Expected behavior:
@@ -327,6 +358,10 @@ function test_user_additions()
 
     @testset "Dependency-ordered subcommodity writes" begin
         test_subcommodities_dependency_write_order()
+    end
+
+    @testset "Commodity materialization" begin
+        test_materialize_user_commodities()
     end
 
     @testset "User asset loading scope" begin

--- a/test/test_workflow.jl
+++ b/test/test_workflow.jl
@@ -2,10 +2,9 @@ module TestWorkflow
 
 using Test
 using HiGHS
-using Pkg
 using JuMP
-try Pkg.add("Gurobi"); using Gurobi; catch e end
 using CSV, DataFrames, JSON3
+import MacroEnergy
 import MacroEnergy:
     System,
     AbstractEdge,
@@ -62,7 +61,8 @@ include("utilities.jl")
 include("test_timedata.jl")
 const test_path = joinpath(@__DIR__, "test_inputs")
 const system_data_true_path = joinpath(@__DIR__, "test_inputs/system_data_true.json")
-const optim = is_gurobi_available() ? Gurobi.Optimizer : HiGHS.Optimizer
+const gurobi_available = is_gurobi_available()
+const optim = gurobi_available ? Gurobi.Optimizer : HiGHS.Optimizer
 const obj_true = 1.551272176298086e11
 
 function test_configure_settings(data::NamedTuple, data_true::T) where {T<:JSON3.Object}

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -28,7 +28,16 @@ macro error_logger(block)
 end
 
 function is_gurobi_available()
-    return !isnothing(Base.get_extension(@__MODULE__, :MacroEnergyGurobiExt))
+    Base.find_package("Gurobi") === nothing && return false
+
+    try
+        @eval using Gurobi
+        return !isnothing(Base.get_extension(MacroEnergy, :MacroEnergyGurobiExt))
+    catch e
+        @warn "Gurobi is available but could not be loaded; using HiGHS for tests" exception =
+            (e, catch_backtrace())
+        return false
+    end
 end
 
 function check_if_package_installed(optimizer_name::AbstractString)


### PR DESCRIPTION
## Description

This PR adds repository-local tools for comparing model-build performance between `upstream/main` and your current branch, including uncommitted changes. These are some tools I've used to help steer improvements and I thought it would be useful for others. I'm more than happy for people to add to or change the workflows.

To run the benchmarking (with multisector_3zone by default), run:

`julia --project=. benchmark/run.jl`

The benchmark runner currently:

- downloads and version-pins benchmark examples locally;
- measures case loading, case generation, and model generation;
- runs each revision in its own Julia process and worktree;
- reports median time, allocations, and allocated bytes in the terminal and a single ignored JSON results file;
- supports examples with runtime user additions.

This is intended for local developer investigation only. It adds no CI benchmark threshold or public package API.

I also added some tests to help make sure it runs in the future:

- Added unit tests for benchmark example/version-marker handling and result-summary helpers.
- Manually ran the benchmark runner against `multisector_3zone`.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.