### PR TITLE
Remove intermediate expressions from balance constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project follows Julia package versioning through `Project.toml` release
 - Updated MacroEnergySolvers.jl version to 0.2.2.
 - Updated MacroEnergyScaling.jl compatibility to 0.4. Constraint scaling now updates constraints in place, so existing JuMP `ConstraintRef`s remain valid instead of being invalidated by constraint replacement. This version also allows for objective scaling in the future.
 - Hoisted repeated time-data lookups during model construction and simplified ramping and minimum up/down-time constraints to avoid temporary expression and index containers.
+- Reduced model-generation allocations in edge balance updates by inserting flow variables directly into vertex balance expressions instead of constructing temporary effective-flow expressions.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroEnergy"
 uuid = "260b7737-bf0e-4e84-9335-3af14438b1f5"
-version = "0.3.0-dev6"
+version = "0.3.0-dev7"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/References/5_utilities.md
+++ b/docs/src/References/5_utilities.md
@@ -19,6 +19,11 @@ MacroEnergy.all_constraints_types
 MacroEnergy.array_container
 ```
 
+## `add_flow_to_vertex_balances!`
+```@docs
+MacroEnergy.add_flow_to_vertex_balances!
+```
+
 ## `asset_ids`
 ```@docs
 MacroEnergy.asset_ids

--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -842,18 +842,31 @@ function update_startup_fuel_balance!(e::EdgeWithUC)
 
 end
 
-function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effective_flow::Union{AffExprArrayOrDense,VarArrayOrDense}, outgoing::Bool)
+"""
+    add_flow_to_vertex_balances!(e, v, effective_flow, outgoing)
+
+Add an edge's effective flow to each matching balance on `v`. `effective_flow(t)`
+returns the flow expression at time `t`; accepting a callable avoids materializing an
+intermediate time-indexed expression container solely for this update.
+"""
+function add_flow_to_vertex_balances!(
+    e::AbstractEdge,
+    v::AbstractVertex,
+    effective_flow::F,
+    outgoing::Bool,
+) where {F}
     if outgoing
         flow_dir = -1.0
     else
         flow_dir = 1.0
     end
+    ti = time_interval(e)
     for i in keys(v.balance_data)
         data = balance_data(v, i)
         if isempty(data.terms) && data.constant == 0.0
             balance_expr = (get_balance(v, i)::AffExprArrayOrDense)
-            for t in time_interval(e)
-                add_to_expression!(balance_expr[t], flow_dir, effective_flow[t])
+            for t in ti
+                add_to_expression!(balance_expr[t], flow_dir, effective_flow(t))
             end
             continue
         end
@@ -880,13 +893,13 @@ function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effect
             if balance_coeff == 0.0
                 continue
             end
-            for t in time_interval(e)
-                add_to_expression!(balance_expr[t], balance_coeff, effective_flow[t])
+            for t in ti
+                add_to_expression!(balance_expr[t], balance_coeff, effective_flow(t))
             end
             continue
         end
 
-        for (time_index, t) in enumerate(time_interval(e))
+        for (time_index, t) in enumerate(ti)
             balance_coeff = scalar_coeff
             for term in data.terms
                 if balance_term_matches(term, e, :flow) && !(term.coeff isa Float64)
@@ -897,7 +910,7 @@ function add_flow_to_vertex_balances!(e::AbstractEdge, v::AbstractVertex, effect
             if balance_coeff == 0.0
                 continue
             end
-            add_to_expression!(balance_expr[t], balance_coeff, effective_flow[t])
+            add_to_expression!(balance_expr[t], balance_coeff, effective_flow(t))
         end
     end
 end
@@ -906,8 +919,7 @@ function update_balance_start!(e::AbstractEdge, model::Model)
     # This implicitly works for UnidirectionalEdge and EdgeWithUC
     # BidirectionalEdge is handled in a separate method
     v = start_vertex(e)
-    effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
-    add_flow_to_vertex_balances!(e, v, effective_flow, true)
+    add_flow_to_vertex_balances!(e, v, t -> flow(e, t), true)
 end
 
 function update_balance_start!(e::BidirectionalEdge, model::Model)
@@ -919,17 +931,20 @@ function update_balance_start!(e::BidirectionalEdge, model::Model)
         if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
             @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
         end
-        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow_pos[t] - (1 - loss_fraction(e,t)) * flow_neg[t])
+        add_flow_to_vertex_balances!(
+            e,
+            v,
+            t -> flow_pos[t] - (1 - loss_fraction(e, t)) * flow_neg[t],
+            true,
+        )
     else
-        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
+        add_flow_to_vertex_balances!(e, v, t -> flow(e, t), true)
     end
-    add_flow_to_vertex_balances!(e, v, effective_flow, true)
 end
 
 function update_balance_end!(e::AbstractEdge, model::Model)
     v = end_vertex(e)
-    effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), (1-loss_fraction(e,t)) * flow(e, t))
-    add_flow_to_vertex_balances!(e, v, effective_flow, false)
+    add_flow_to_vertex_balances!(e, v, t -> (1 - loss_fraction(e, t)) * flow(e, t), false)
 end
 
 function update_balance_end!(e::BidirectionalEdge, model::Model)
@@ -941,9 +956,13 @@ function update_balance_end!(e::BidirectionalEdge, model::Model)
         if has_capacity(e) && any(isa.(e.constraints, CapacityConstraint))
             @constraint(model, [t in time_interval(e)], flow_pos[t] + flow_neg[t] <= availability(e, t) * capacity(e))
         end        
-        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), (1 - loss_fraction(e,t)) * flow_pos[t] - flow_neg[t])
+        add_flow_to_vertex_balances!(
+            e,
+            v,
+            t -> (1 - loss_fraction(e, t)) * flow_pos[t] - flow_neg[t],
+            false,
+        )
     else
-        effective_flow = @expression(model, [t in time_interval(e)], container = array_container(time_interval(e)), flow(e, t))
+        add_flow_to_vertex_balances!(e, v, t -> flow(e, t), false)
     end
-    add_flow_to_vertex_balances!(e, v, effective_flow, false)
 end

--- a/src/model/networks/edge.jl
+++ b/src/model/networks/edge.jl
@@ -843,16 +843,16 @@ function update_startup_fuel_balance!(e::EdgeWithUC)
 end
 
 """
-    add_flow_to_vertex_balances!(e, v, effective_flow, outgoing)
+    add_flow_to_vertex_balances!(e, v, add_effective_flow!, outgoing)
 
-Add an edge's effective flow to each matching balance on `v`. `effective_flow(t)`
-returns the flow expression at time `t`; accepting a callable avoids materializing an
-intermediate time-indexed expression container solely for this update.
+Add an edge's effective flow to each matching balance on `v`. `add_effective_flow!`
+directly adds the effective flow's variable terms to a balance expression, avoiding
+both an indexed expression container and temporary scalar affine expressions.
 """
 function add_flow_to_vertex_balances!(
     e::AbstractEdge,
     v::AbstractVertex,
-    effective_flow::F,
+    add_effective_flow!::F,
     outgoing::Bool,
 ) where {F}
     if outgoing
@@ -866,7 +866,7 @@ function add_flow_to_vertex_balances!(
         if isempty(data.terms) && data.constant == 0.0
             balance_expr = (get_balance(v, i)::AffExprArrayOrDense)
             for t in ti
-                add_to_expression!(balance_expr[t], flow_dir, effective_flow(t))
+                add_effective_flow!(balance_expr[t], flow_dir, t)
             end
             continue
         end
@@ -894,7 +894,7 @@ function add_flow_to_vertex_balances!(
                 continue
             end
             for t in ti
-                add_to_expression!(balance_expr[t], balance_coeff, effective_flow(t))
+                add_effective_flow!(balance_expr[t], balance_coeff, t)
             end
             continue
         end
@@ -910,7 +910,7 @@ function add_flow_to_vertex_balances!(
             if balance_coeff == 0.0
                 continue
             end
-            add_to_expression!(balance_expr[t], balance_coeff, effective_flow(t))
+            add_effective_flow!(balance_expr[t], balance_coeff, t)
         end
     end
 end
@@ -919,7 +919,7 @@ function update_balance_start!(e::AbstractEdge, model::Model)
     # This implicitly works for UnidirectionalEdge and EdgeWithUC
     # BidirectionalEdge is handled in a separate method
     v = start_vertex(e)
-    add_flow_to_vertex_balances!(e, v, t -> flow(e, t), true)
+    add_flow_to_vertex_balances!(e, v, (expr, coeff, t) -> add_to_expression!(expr, coeff, flow(e, t)), true)
 end
 
 function update_balance_start!(e::BidirectionalEdge, model::Model)
@@ -934,17 +934,25 @@ function update_balance_start!(e::BidirectionalEdge, model::Model)
         add_flow_to_vertex_balances!(
             e,
             v,
-            t -> flow_pos[t] - (1 - loss_fraction(e, t)) * flow_neg[t],
+            (expr, coeff, t) -> begin
+                add_to_expression!(expr, coeff, flow_pos[t])
+                add_to_expression!(expr, -coeff * (1 - loss_fraction(e, t)), flow_neg[t])
+            end,
             true,
         )
     else
-        add_flow_to_vertex_balances!(e, v, t -> flow(e, t), true)
+        add_flow_to_vertex_balances!(e, v, (expr, coeff, t) -> add_to_expression!(expr, coeff, flow(e, t)), true)
     end
 end
 
 function update_balance_end!(e::AbstractEdge, model::Model)
     v = end_vertex(e)
-    add_flow_to_vertex_balances!(e, v, t -> (1 - loss_fraction(e, t)) * flow(e, t), false)
+    add_flow_to_vertex_balances!(
+        e,
+        v,
+        (expr, coeff, t) -> add_to_expression!(expr, coeff * (1 - loss_fraction(e, t)), flow(e, t)),
+        false,
+    )
 end
 
 function update_balance_end!(e::BidirectionalEdge, model::Model)
@@ -959,10 +967,13 @@ function update_balance_end!(e::BidirectionalEdge, model::Model)
         add_flow_to_vertex_balances!(
             e,
             v,
-            t -> (1 - loss_fraction(e, t)) * flow_pos[t] - flow_neg[t],
+            (expr, coeff, t) -> begin
+                add_to_expression!(expr, coeff * (1 - loss_fraction(e, t)), flow_pos[t])
+                add_to_expression!(expr, -coeff, flow_neg[t])
+            end,
             false,
         )
     else
-        add_flow_to_vertex_balances!(e, v, t -> flow(e, t), false)
+        add_flow_to_vertex_balances!(e, v, (expr, coeff, t) -> add_to_expression!(expr, coeff, flow(e, t)), false)
     end
 end


### PR DESCRIPTION
## Description

This PR reduces model-generation memory use by avoiding temporary JuMP expressions when edge flows are added to vertex balance equations.

Edge-specific multiple-dispatch methods now insert the underlying flow variables directly into the relevant balance expression with the appropriate sign and coefficient. This preserves the formulation while avoiding allocation-heavy intermediate effective-flow expressions.

Benchmarking on the regular examples, I saw a ~25% reduction in allocations and ~9% reduction in model build time.

## Type of change
Please delete options that are not relevant.

- [x] Performance improvement (please add a section below for benchmark results or performance metrics)

## Related Issues

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.