### PR TITLE
Fix documentation markdown and formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project follows Julia package versioning through `Project.toml` release
 
 ### Documentation
 
+- Switched documentation math rendering to MathJax3 and pinned Mermaid to 11.16.1 to avoid Mermaid 11.17's RequireJS compatibility regression.
 - Expanded the balance documentation with guidance on choosing between balance macros, stoichiometric coefficient bases, pairwise expansion limits, multi-term algebraic balances, common mistakes, and numerical sensitivity.
 - Updated modeler documentation to include balance APIs in the asset-construction workflow and to recommend a small single-asset regression test for each new asset.
 - Updated debugging guidance around `balance_data`, `get_balance`, and `@inspect_stoichiometric_balance`.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,3 +6,6 @@ DocumenterMermaid = "a078cd44-4d9c-4618-b545-3ab9d77f9177"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroEnergy = "260b7737-bf0e-4e84-9335-3af14438b1f5"
+
+[sources]
+DocumenterMermaid = {url = "https://github.com/RuaridhMacd/DocumenterMermaid.jl", rev = "8e2d9bd94f3e2f60ef48180235b72249754bf64e"}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -156,6 +156,7 @@ makedocs(;
         canonical="https://macroenergy.github.io/Macro/stable/",
         # sidebar_sitename = false,
         collapselevel=1,
+        mathengine=Documenter.MathJax3(),
     ),
     pages=pages,
 )


### PR DESCRIPTION
## Description

This PR fixes two related issues in how documentation is being rendered. These issues stem from a bug in the mermaid library ([here](https://github.com/mermaid-js/mermaid/issues/8095)). [A fix for that is under review](https://github.com/mermaid-js/mermaid/pull/8154) so we could reverse these changes in the future. However, pinning our own version of Mermaid will also avoid this issue in the future.

The changes are:

- Switch documentation math rendering from Documenter’s default KaTeX/RequireJS path to Documenter.MathJax3().
- Pin DocumenterMermaid.jl to a temporary MacroEnergy fork at a fixed commit.
- The fork pins Mermaid from floating mermaid@11 to mermaid@11.16.1.

This fixes the Mermaid 11.17 AMD/RequireJS regression that prevented Mermaid diagrams from initializing in the deployed docs, and avoids the related KaTeX/RequireJS errors affecting mathematical formulas.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

This issues was raised by @HongxiLuo 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.

## How to test the code
Reference to an example case or a test case that can be run to verify the changes.

## Additional context
Add any other context about the PR here. If you have any questions, please contact the maintainers.