### PR TITLE
Extend storage charge/discharge limit constraints to LongDurationStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project follows Julia package versioning through `Project.toml` release
 - Updated MacroEnergyScaling.jl compatibility to 0.4. Constraint scaling now updates constraints in place, so existing JuMP `ConstraintRef`s remain valid instead of being invalidated by constraint replacement. This version also allows for objective scaling in the future.
 - Hoisted repeated time-data lookups during model construction and simplified ramping and minimum up/down-time constraints to avoid temporary expression and index containers.
 - Weight policy slack to ensure CO2 slack penalty has economic interpretation.
+- Storage Charge/Discharge limit constraints now can be applied to `LongDurationStorage`.
 
 ### Fixed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -32,6 +32,7 @@ and this project follows Julia package versioning through `Project.toml` release
 - Updated MacroEnergyScaling.jl compatibility to 0.4. Constraint scaling now updates constraints in place, so existing JuMP `ConstraintRef`s remain valid instead of being invalidated by constraint replacement. This version also allows for objective scaling in the future.
 - Hoisted repeated time-data lookups during model construction and simplified ramping and minimum up/down-time constraints to avoid temporary expression and index containers.
 - Weight policy slack to ensure CO2 slack penalty has economic interpretation.
+- Storage Charge/Discharge limit constraints now can be applied to `LongDurationStorage`.
 
 ### Fixed
 
@@ -41,6 +42,7 @@ and this project follows Julia package versioning through `Project.toml` release
 
 ### Documentation
 
+- Switched documentation math rendering to MathJax3 and pinned Mermaid to 11.16.1 to avoid Mermaid 11.17's RequireJS compatibility regression.
 - Expanded the balance documentation with guidance on choosing between balance macros, stoichiometric coefficient bases, pairwise expansion limits, multi-term algebraic balances, common mistakes, and numerical sensitivity.
 - Updated modeler documentation to include balance APIs in the asset-construction workflow and to recommend a small single-asset regression test for each new asset.
 - Updated debugging guidance around `balance_data`, `get_balance`, and `@inspect_stoichiometric_balance`.

--- a/src/model/constraints/storage_charge_limit.jl
+++ b/src/model/constraints/storage_charge_limit.jl
@@ -24,13 +24,14 @@ for each time `t` in `time_interval(e)` for the edge `e`. The function [`timeste
 """
 function add_model_constraint!(ct::StorageChargeLimitConstraint, e::AbstractEdge, model::Model)
 
-    if isa(end_vertex(e), Storage)
+    if isa(end_vertex(e), AbstractStorage)
         storage_data = balance_data(end_vertex(e), :storage)
+        prev = previous_storage_level(end_vertex(e), model)
         ct.constraint_ref = @constraint(
             model,
             [t in time_interval(e)],
             balance_term_coefficient(storage_data, e, end_vertex(e), t) * flow(e, t) <=
-            capacity(end_vertex(e)) - storage_level(end_vertex(e), timestepbefore(t, 1, subperiods(e)))
+            capacity(end_vertex(e)) - prev[t]
         )
     end
 

--- a/src/model/constraints/storage_discharge_limit.jl
+++ b/src/model/constraints/storage_discharge_limit.jl
@@ -25,13 +25,14 @@ for each time `t` in `time_interval(e)` for the edge `e`. The function [`timeste
 """
 function add_model_constraint!(ct::StorageDischargeLimitConstraint, e::AbstractEdge, model::Model)
 
-    if isa(start_vertex(e), Storage)
+    if isa(start_vertex(e), AbstractStorage)
         storage_data = balance_data(start_vertex(e), :storage)
+        prev = previous_storage_level(start_vertex(e), model)
         ct.constraint_ref = @constraint(
             model,
             [t in time_interval(e)],
             balance_term_coefficient(storage_data, e, start_vertex(e), t) * flow(e, t) <=
-            storage_level(start_vertex(e), timestepbefore(t, 1, subperiods(e)))
+            prev[t]
         )
     end
 

--- a/src/model/networks/storage.jl
+++ b/src/model/networks/storage.jl
@@ -421,6 +421,33 @@ function operation_model!(g::LongDurationStorage, model::Model)
 
 end
 
+function previous_storage_level(g::Storage, model::Model)
+    ti = time_interval(g)
+    time_container = array_container(ti)
+    sps = subperiods(g)
+    return @expression(
+        model, 
+        [t in ti],
+        container = time_container,
+        storage_level(g, timestepbefore(t, 1, sps)))
+end
+
+function previous_storage_level(g::LongDurationStorage, model::Model)
+    sps = subperiods(g)
+    starts = starts = Set(first(sp) for sp in sps)
+    ti = time_interval(g)
+    time_container = array_container(ti)
+    return @expression(
+        model, 
+        [t in ti], 
+        container = time_container,
+        if t ∈ starts
+            storage_level(g, timestepbefore(t, 1, sps)) - storage_change(g, current_subperiod(g, t))
+        else
+            storage_level(g, timestepbefore(t, 1, sps))
+        end)
+end
+
 function initialize_balance_expression(g::Storage, balance_id::Symbol, model::Model)
     ti = time_interval(g)
     sps = subperiods(g)


### PR DESCRIPTION
## Description
Previous to this PR, storage charge/discharge limit constraints were allowed only for `Storage` concrete type. Now they can also be attached to `LongDurationStorage`. To do this, we have to account for the storage level in the previous time step as defined across different sub-periods.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g., docstrings for new functions, updated/new .md files in the docs folder)
- [x] My changes generate no new warnings
- [x] I have tested the code to ensure it works as expected
- [x] New and existing unit tests pass locally with my changes:
```
julia> using Pkg
julia> Pkg.test("MacroEnergy")
```
- [x] I consent to the use of the [MacroEnergy.jl license](https://github.com/MacroEnergy/MacroEnergy.jl/blob/main/LICENSE) for my contributions.