### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ using Pkg
 Pkg.add("MacroEnergy")
 ```
 
-If you wish to make additons to Macro, please follow the installation instructions in the documentation, [on the Getting Started / Installation page.](https://macroenergy.github.io/MacroEnergy.jl/dev/Getting%20Started/2_installation/)
+If you wish to make additions to Macro, please follow the installation instructions in the documentation, [on the Getting Started / Installation page.](https://macroenergy.github.io/MacroEnergy.jl/dev/Getting%20Started/2_installation/)
 
 ## Recent changes
 
@@ -96,11 +96,11 @@ For the full release history, see [CHANGELOG.md](CHANGELOG.md).
 The Macro documentation [can be found here.](https://macroenergy.github.io/MacroEnergy.jl/). The documentation contains five main resources:
 
 - A getting started section, which shows you how to install and run Macro.
-- Guides, which walk you through how to achieve specfic tasks using Macro.
+- Guides, which walk you through how to achieve specific tasks using Macro.
 - A manual, which describes all the components and features of Macro in detail.
 - Tutorials, which are extended guides with worked examples
 - A function reference, which etails the API and functions available with Macro.
 
 ### Bug reports
 
-Please report any bugs or new feature requrests on [the Issues page of this repository](https://github.com/macroenergy/MacroEnergy.jl/issues).
+Please report any bugs or new feature requests on [the Issues page of this repository](https://github.com/macroenergy/MacroEnergy.jl/issues).

--- a/docs/src/Getting Started/1_overview.md
+++ b/docs/src/Getting Started/1_overview.md
@@ -33,7 +33,7 @@ To create a new sector, you will need to:
 
 1. Create any new Commodities that your sector will require. These Comodities can be energy, material, data, or flows which are important in your new sector.
 2. Create new Assets to represent production, storage, transport, and end-use technologies in your sector. At least some of these should produce, store, transport, and consume your new Commodities.
-3. Assign default inputs for your Assets and specifiy which inputs are optional vs. required.
+3. Assign default inputs for your Assets and specify which inputs are optional vs. required.
 
 ## Helpful packages
 
@@ -63,7 +63,7 @@ To add a Locations to a System, you must [define the constituent Nodes](@ref "Ad
 
 #### 2. Assets
 
-Assets in Macro represent means of producing, storing, transporting, and consuming one or more Commodities. Assets can be sited at a Location, so your Macro System will intuitively represent real-world systems. For example, an Asset can define a power plant that converts a fuel into electricity, which is then assigned to a Location, linking it to the electricity and fuel Nodes at that Location. Each Asset is characterized by a list of Commodities they take as input and output and technical and a range of economic and techical parameters.
+Assets in Macro represent means of producing, storing, transporting, and consuming one or more Commodities. Assets can be sited at a Location, so your Macro System will intuitively represent real-world systems. For example, an Asset can define a power plant that converts a fuel into electricity, which is then assigned to a Location, linking it to the electricity and fuel Nodes at that Location. Each Asset is characterized by a list of Commodities they take as input and output and technical and a range of economic and technical parameters.
 
 Macro has a rich library of Assets already designed and implemented. [You can also create your own Assets.](@ref modeler_create_asset) These can be used just for your project or you can [add it to Macro for others to use](@ref how_to_contribute).
 

--- a/docs/src/Guides/User Guide/user_add_asset.md
+++ b/docs/src/Guides/User Guide/user_add_asset.md
@@ -290,7 +290,7 @@ This is done be calling `template_asset` for each one. This keeps each file simp
 
 ### Create additional instances in one Asset file
 
-This is the recommended appraoch. Each entry in the `instance_data` field corresponds to a version of the Asset. The `type` field determines the Asset which will be created. Assets described in this manner can also share `global_data`, which is [discussed in a subsequent section](@ref "Creating Global Data").
+This is the recommended approach. Each entry in the `instance_data` field corresponds to a version of the Asset. The `type` field determines the Asset which will be created. Assets described in this manner can also share `global_data`, which is [discussed in a subsequent section](@ref "Creating Global Data").
 
 To create additional versions of an Asset in this manner, copy-paste additional entries into the `instance_data` field of your Asset file.
 
@@ -547,7 +547,7 @@ All of the steps described above also work for CSV-based input files, with the e
 
 It is also more challenging to include multiple Asset types in the same file, as it will require many empty columns. Therefore, we recommend using separate Asset files for each type.
 
-For Assets of the same type, each field in the JSON file is replaced with a column. Nested JSON fields have nested CSV headers, with each name separated by a `--` character. This makes it much more prefereable to use the `simple` format for your CSV input files.
+For Assets of the same type, each field in the JSON file is replaced with a column. Nested JSON fields have nested CSV headers, with each name separated by a `--` character. This makes it much more preferable to use the `simple` format for your CSV input files.
 
 A `simple` CSV input file will look like:
 

--- a/docs/src/Guides/User Guide/user_run_model.md
+++ b/docs/src/Guides/User Guide/user_run_model.md
@@ -556,7 +556,7 @@ end
 All the examples above can be executed line by line in an interactive Julia REPL. This is particularly useful for debugging and testing the model. Please check the [Suggested Development Workflow](@ref) and the [Debugging and Testing a Macro Model](@ref) sections for more information.
 
 !!! tip "Interactive Julia REPL"
-    In Julia, when running the same script multiple times, it is recommended to exectute commands or script in an **interactive REPL** (REPL stands for Read-Eval-Print Loop, and it's the command line interface that starts when you type `julia` in the terminal) instead of running the script directly from the terminal. This is because Julia's JIT (Just-In-Time) compiler will compile the code the first time it is run, and subsequent runs will be much faster as the compiled code is cached. Also, the REPL maintains all variables in memory, making it easier to:
+    In Julia, when running the same script multiple times, it is recommended to execute commands or script in an **interactive REPL** (REPL stands for Read-Eval-Print Loop, and it's the command line interface that starts when you type `julia` in the terminal) instead of running the script directly from the terminal. This is because Julia's JIT (Just-In-Time) compiler will compile the code the first time it is run, and subsequent runs will be much faster as the compiled code is cached. Also, the REPL maintains all variables in memory, making it easier to:
     - Inspect variable values;
     - Modify and re-run code without restarting the entire program;
     - Test small code snippets in isolation.

--- a/docs/src/Manual/Edges.md
+++ b/docs/src/Manual/Edges.md
@@ -22,7 +22,7 @@ Most edges are incorporated into Assets, representing the ability of those Asset
 
 #### Electricity Edges in a transmission line
 
-A simple transmission line Asset has a strong correspondance between the physical component and its representation in Macro. A transmission line Asset can be defined as a `BidirectionalEdge{Electricity}` between two Electricity Nodes (aka. two `Node{Electricty}`). The transmission of electricity is represented by the operational variables of the `BidirectionalEdge{Electricity}`, and those variables are limited by its investment variables. The costs which come with those operations and investments are associated with that edge.
+A simple transmission line Asset has a strong correspondence between the physical component and its representation in Macro. A transmission line Asset can be defined as a `BidirectionalEdge{Electricity}` between two Electricity Nodes (aka. two `Node{Electricty}`). The transmission of electricity is represented by the operational variables of the `BidirectionalEdge{Electricity}`, and those variables are limited by its investment variables. The costs which come with those operations and investments are associated with that edge.
 
 #### Electricity Edges in a natural gas power plant
 
@@ -32,7 +32,7 @@ It might be intuitive to think of the `Transformation` as the power plant and th
 
 ### Edges outside of Assets
 
-It is not currently possible to define `Edges` outside of Assets using the standard input files. We believe most users will be better served using a simple Asset to represent a connection. However, it is possible to define `Edges` directly in the Julia script you use to build and solve your model. Please feel free to reach out to the developemnt team via a GitHub issue if you have a use case for this.
+It is not currently possible to define `Edges` outside of Assets using the standard input files. We believe most users will be better served using a simple Asset to represent a connection. However, it is possible to define `Edges` directly in the Julia script you use to build and solve your model. Please feel free to reach out to the development team via a GitHub issue if you have a use case for this.
 
 ### Key Concepts
 

--- a/docs/src/Manual/Nodes.md
+++ b/docs/src/Manual/Nodes.md
@@ -307,7 +307,7 @@ In this example, we'll define two Electricity Nodes with non-served demand (NSD)
 
 1. Providing a vector of demand segments in the `max_nsd` field. Each segment is the fraction of this Nodes's demand that can be met by NSD each time step. A value of `[1.0]` indicated that the entire demand can be non-served.  
 2. Providing a vector of prices in the `price_nsd` field, of the same length as the `max_nsd` field. Each segment is the price per MWh of non-served demand for the corresponding segment. Here, we have defined a NSD price of \$5000/MWh.
-3. We have to add a `MaxNonServedDemandConstraint` constraint to the `constraints` field to enfore the NSD limit. If we wish to use multiple segments, we also need to add a `MaxNonServedDemandPerSegmentConstraint` constraint.
+3. We have to add a `MaxNonServedDemandConstraint` constraint to the `constraints` field to enforce the NSD limit. If we wish to use multiple segments, we also need to add a `MaxNonServedDemandPerSegmentConstraint` constraint.
 
 We want both Nodes to have the same NSD limits, so we can define these in the `global_data` field. To define different limits or prices, we could move the `max_nsd` and / or `price_nsd` fields to the `instance_data` field of each Node.
 

--- a/docs/src/Manual/Storage.md
+++ b/docs/src/Manual/Storage.md
@@ -36,7 +36,7 @@ While single period cycles are fine for storage which usually discharge within t
 
 ### Storage Outside of Assets
 
-`Storage` components can be used outside of Assets but there is no standard inputs file to do so currently. Most Users will be better served by using `Storage` components within Assets, as this allows for more complex interactions and configurations. However, it is possible to define `Storages` directly in the Julia script you use to build and solve your model. Please feel free to reach out to the developemnt team via a GitHub issue if you have a use case for this.
+`Storage` components can be used outside of Assets but there is no standard inputs file to do so currently. Most Users will be better served by using `Storage` components within Assets, as this allows for more complex interactions and configurations. However, it is possible to define `Storages` directly in the Julia script you use to build and solve your model. Please feel free to reach out to the development team via a GitHub issue if you have a use case for this.
 
 ### Key Concepts
 
@@ -54,7 +54,7 @@ While single period cycles are fine for storage which usually discharge within t
 `Storage` components have the following fields. When running a model, the fields are set by the input files. When creating an Asset, the defaults below can be altered using the `@storage_data` macro. The internal fields are used by Macro and are not intended to be set by users in most circumstances.
 
 !!! note "Units in Macro"
-    In the tables below, we have assumed that the Storage component compoent in question is storing energy, such as electricity or heat. Therefore the unit of storage is MWh. Please swap these for tonnes or other units as appropriate for your use case. We have also assumed that your System is using hour-long time steps. You can use any set of units as long as they are consistent across your operations and investment inputs.
+    In the tables below, we have assumed that the Storage component component in question is storing energy, such as electricity or heat. Therefore the unit of storage is MWh. Please swap these for tonnes or other units as appropriate for your use case. We have also assumed that your System is using hour-long time steps. You can use any set of units as long as they are consistent across your operations and investment inputs.
 
 ### Network Structure
 

--- a/docs/src/Manual/assets/beccshydrogen.md
+++ b/docs/src/Manual/assets/beccshydrogen.md
@@ -157,7 +157,7 @@ The following tables outline the attributes that can be set for a BECCS hydrogen
 | `co2_sink` | String | ID of a CO₂ sink vertex (must be defined in the nodes input file) |
 
 ### [Conversion Process Parameters](@id beccshydrogen_conversion_process_parameters)
-The following set of parameters control the converssion process and stoichiometry of the BECCS hydrogen asset (see [Flow Equations](@ref beccshydrogen_flow_equations) for more details).
+The following set of parameters control the conversion process and stoichiometry of the BECCS hydrogen asset (see [Flow Equations](@ref beccshydrogen_flow_equations) for more details).
 
 | Field | Type | Description | Units | Default |
 |--------------|---------|------------|----------------|----------|


### PR DESCRIPTION
Fixes 14 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed.